### PR TITLE
Add theme:refresh and scheduled-task:register to run execution

### DIFF
--- a/src/Services/UpgradeManager.php
+++ b/src/Services/UpgradeManager.php
@@ -49,6 +49,8 @@ class UpgradeManager
         }
 
         $this->processHelper->console(['plugin:refresh']);
+        $this->processHelper->console(['theme:refresh']);
+        $this->processHelper->console(['scheduled-task:register']);
 
         $this->pluginHelper->installPlugins($configuration->skipAssetInstall);
         $this->pluginHelper->updatePlugins($configuration->skipAssetInstall);

--- a/tests/Services/UpgradeManagerTest.php
+++ b/tests/Services/UpgradeManagerTest.php
@@ -112,7 +112,7 @@ class UpgradeManagerTest extends TestCase
 
         $manager->run(new RunConfiguration(true, true), $this->createMock(OutputInterface::class));
 
-        static::assertCount(2, $consoleCommands);
+        static::assertCount(4, $consoleCommands);
         static::assertSame(['system:update:finish', '--skip-asset-build'], $consoleCommands[0]);
     }
 
@@ -150,7 +150,7 @@ class UpgradeManagerTest extends TestCase
 
         $manager->run(new RunConfiguration(), $this->createMock(OutputInterface::class));
 
-        static::assertCount(3, $consoleCommands);
+        static::assertCount(5, $consoleCommands);
         static::assertSame(['sales-channel:create:storefront', '--name=Storefront', '--url=http://localhost'], $consoleCommands[0]);
     }
 }


### PR DESCRIPTION
Normally, these cases should be handled by plugin:update. But themes and scheduled tasks can also be added by bundles.