### PR TITLE
feat: add fastly support, fixes #19

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -15,6 +15,7 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\XmlDumper;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
 use Symfony\Component\EventDispatcher\DependencyInjection\RegisterListenersPass;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -40,6 +41,10 @@ class Application extends SymfonyApplication
         $container = new ContainerBuilder();
         $container->registerAttributeForAutoconfiguration(AsCommand::class, function (ChildDefinition $definition): void {
             $definition->addTag('console.command');
+        });
+
+        $container->registerAttributeForAutoconfiguration(AsEventListener::class, function (ChildDefinition $definition): void {
+            $definition->addTag('kernel.event_listener');
         });
 
         $container->addCompilerPass(new AddConsoleCommandPass());

--- a/src/Command/FastlySnippetListCommand.php
+++ b/src/Command/FastlySnippetListCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Command;
+
+use Shopware\Deployment\Helper\EnvironmentHelper;
+use Shopware\Deployment\Integration\Fastly\FastlyAPIClient;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'fastly:snippet:list',
+    description: 'List all Fastly snippets'
+)]
+class FastlySnippetListCommand extends Command
+{
+    public function __construct(private readonly FastlyAPIClient $fastlyAPIClient)
+    {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $apiToken = EnvironmentHelper::getVariable('FASTLY_API_TOKEN', '');
+        $serviceId = EnvironmentHelper::getVariable('FASTLY_SERVICE_ID', '');
+
+        if ($apiToken === '' || $serviceId === '') {
+            $output->writeln('FASTLY_API_TOKEN or FASTLY_SERVICE_ID is not set.');
+
+            return self::FAILURE;
+        }
+
+        $this->fastlyAPIClient->setApiKey($apiToken);
+
+        $currentlyActiveVersion = $this->fastlyAPIClient->getCurrentlyActiveVersion($serviceId);
+
+        $snippets = $this->fastlyAPIClient->listSnippets($serviceId, $currentlyActiveVersion);
+
+        $table = new Table($output);
+        $table->setHeaders(['Name', 'Type', 'Priority', 'Last change']);
+
+        foreach ($snippets as $snippet) {
+            $table->addRow([$snippet['name'], $snippet['type'], $snippet['priority'], $snippet['updated_at']]);
+        }
+
+        $table->render();
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Command/FastlySnippetRemoveCommand.php
+++ b/src/Command/FastlySnippetRemoveCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Command;
+
+use Shopware\Deployment\Helper\EnvironmentHelper;
+use Shopware\Deployment\Integration\Fastly\FastlyAPIClient;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'fastly:snippet:remove',
+    description: 'Remove a Fastly snippet'
+)]
+class FastlySnippetRemoveCommand extends Command
+{
+    public function __construct(private readonly FastlyAPIClient $fastlyAPIClient)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('snippetName', InputArgument::REQUIRED, 'The name of the snippet to remove');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $apiToken = EnvironmentHelper::getVariable('FASTLY_API_TOKEN', '');
+        $serviceId = EnvironmentHelper::getVariable('FASTLY_SERVICE_ID', '');
+
+        if ($apiToken === '' || $serviceId === '') {
+            $output->writeln('FASTLY_API_TOKEN or FASTLY_SERVICE_ID is not set.');
+
+            return self::FAILURE;
+        }
+
+        $this->fastlyAPIClient->setApiKey($apiToken);
+
+        $currentlyActiveVersion = $this->fastlyAPIClient->getCurrentlyActiveVersion($serviceId);
+
+        $snippetName = $input->getArgument('snippetName');
+
+        $newVersionId = $this->fastlyAPIClient->cloneServiceVersion($serviceId, $currentlyActiveVersion);
+
+        $this->fastlyAPIClient->deleteSnippet($serviceId, $newVersionId, $snippetName);
+
+        $this->fastlyAPIClient->activateServiceVersion($serviceId, $newVersionId);
+
+        $output->writeln('Snippet removed.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopware\Deployment\Command;
 
+use Shopware\Deployment\Event\PostDeploy;
 use Shopware\Deployment\Services\HookExecutor;
 use Shopware\Deployment\Services\InstallationManager;
 use Shopware\Deployment\Services\ShopwareState;
@@ -14,6 +15,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 #[AsCommand('run', description: 'Install or Update Shopware')]
 class RunCommand extends Command
@@ -23,6 +25,7 @@ class RunCommand extends Command
         private readonly InstallationManager $installationManager,
         private readonly UpgradeManager $upgradeManager,
         private readonly HookExecutor $hookExecutor,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
         parent::__construct();
     }
@@ -54,6 +57,8 @@ class RunCommand extends Command
         } else {
             $this->installationManager->run($config, $output);
         }
+
+        $this->eventDispatcher->dispatch(new PostDeploy($config, $output));
 
         $this->hookExecutor->execute(HookExecutor::HOOK_POST);
 

--- a/src/Event/PostDeploy.php
+++ b/src/Event/PostDeploy.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Event;
+
+use Shopware\Deployment\Struct\RunConfiguration;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
+
+#[Exclude]
+readonly class PostDeploy
+{
+    public function __construct(public readonly RunConfiguration $configuration, public readonly OutputInterface $output)
+    {
+    }
+}

--- a/src/Integration/Fastly/FastlyAPIClient.php
+++ b/src/Integration/Fastly/FastlyAPIClient.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Integration\Fastly;
+
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @phpstan-type Snippet array{name: string, type: string, content: string, priority: int, updated_at: string}
+ */
+class FastlyAPIClient
+{
+    private HttpClientInterface $client;
+    private HttpClientInterface $baseClient;
+
+    public function __construct(?HttpClientInterface $baseClient = null)
+    {
+        $this->baseClient = $baseClient ?? HttpClient::createForBaseUri('https://api.fastly.com');
+    }
+
+    public function setApiKey(string $apiKey): void
+    {
+        $this->client = $this->baseClient->withOptions([
+            'headers' => [
+                'Fastly-Key' => $apiKey,
+                'Accept' => 'application/json',
+            ],
+        ]);
+    }
+
+    /**
+     * @return Snippet[]
+     */
+    public function listSnippets(string $serviceId, int $version): array
+    {
+        $snippets = $this->client->request('GET', \sprintf('/service/%s/version/%d/snippet', $serviceId, $version))->toArray();
+
+        return $snippets;
+    }
+
+    public function createSnippet(string $serviceId, int $version, string $name, string $type, string $content, int $priority): void
+    {
+        $this->client->request('POST', \sprintf('/service/%s/version/%d/snippet', $serviceId, $version), [
+            'json' => [
+                'name' => $name,
+                'type' => $type,
+                'content' => $content,
+                'dynamic' => 0,
+                'priority' => $priority,
+            ],
+        ]);
+    }
+
+    public function updateSnippet(string $serviceId, int $version, string $name, string $type, string $content, int $priority): void
+    {
+        $this->client->request('PUT', \sprintf('/service/%s/version/%d/snippet/%s', $serviceId, $version, $name), [
+            'json' => [
+                'type' => $type,
+                'content' => $content,
+                'priority' => $priority,
+            ],
+        ]);
+    }
+
+    public function deleteSnippet(string $serviceId, int $version, string $name): void
+    {
+        $this->client->request('DELETE', \sprintf('/service/%s/version/%d/snippet/%s', $serviceId, $version, $name))->toArray();
+    }
+
+    public function cloneServiceVersion(string $serviceId, int $version): int
+    {
+        $response = $this->client->request('PUT', \sprintf('/service/%s/version/%d/clone', $serviceId, $version));
+
+        $data = $response->toArray();
+
+        return $data['number'];
+    }
+
+    public function activateServiceVersion(string $serviceId, int $version): void
+    {
+        $this->client->request('PUT', \sprintf('/service/%s/version/%d/activate', $serviceId, $version))->toArray();
+    }
+
+    public function getCurrentlyActiveVersion(string $serviceId): int
+    {
+        $response = $this->client->request('GET', \sprintf('/service/%s/version/active', $serviceId));
+
+        $data = $response->toArray();
+
+        return $data['number'];
+    }
+}

--- a/src/Integration/Fastly/FastlyContext.php
+++ b/src/Integration/Fastly/FastlyContext.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Integration\Fastly;
+
+use Symfony\Component\DependencyInjection\Attribute\Exclude;
+
+/**
+ * @phpstan-import-type Snippet from FastlyAPIClient
+ */
+#[Exclude]
+class FastlyContext
+{
+    /**
+     * @param Snippet[] $snippets
+     */
+    public function __construct(
+        public array $snippets,
+        public string $serviceId,
+        public int $currentlyActiveVersion,
+        public ?int $createdVersion = null)
+    {
+    }
+
+    public function hasSnippet(string $snippetName): bool
+    {
+        foreach ($this->snippets as $snippet) {
+            if ($snippet['name'] === $snippetName) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function hasSnippetChanged(string $snippetName, string $content): bool
+    {
+        foreach ($this->snippets as $snippet) {
+            if ($snippet['name'] === $snippetName && $snippet['content'] !== $content) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Integration/Fastly/FastlyServiceUpdater.php
+++ b/src/Integration/Fastly/FastlyServiceUpdater.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Integration\Fastly;
+
+use Shopware\Deployment\Event\PostDeploy;
+use Shopware\Deployment\Helper\EnvironmentHelper;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+
+#[AsEventListener(event: PostDeploy::class, method: '__invoke')]
+class FastlyServiceUpdater
+{
+    private const FILE_NAME_REGEX = '/^(?<name>\w+)\.?(?<priority>\d+)?\.vcl$/m';
+
+    public function __construct(
+        #[Autowire('%kernel.project_dir%')]
+        private readonly string $projectDir,
+        private readonly FastlyAPIClient $fastlyAPIClient,
+        private readonly Filesystem $filesystem = new Filesystem(),
+    ) {
+    }
+
+    public function __invoke(PostDeploy $event): void
+    {
+        $fastlyConfigPath = Path::join($this->projectDir, 'config', 'fastly');
+        if (!$this->filesystem->exists($fastlyConfigPath)) {
+            return;
+        }
+
+        $apiToken = EnvironmentHelper::getVariable('FASTLY_API_TOKEN', '');
+        $serviceId = EnvironmentHelper::getVariable('FASTLY_SERVICE_ID', '');
+
+        $io = new SymfonyStyle(new ArgvInput(), $event->output);
+
+        if ($apiToken === '' || $serviceId === '') {
+            $io->info('FASTLY_API_TOKEN or FASTLY_SERVICE_ID is not set. Skipping Fastly service update.');
+
+            return;
+        }
+
+        $this->fastlyAPIClient->setApiKey($apiToken);
+
+        $currentlyActiveVersion = $this->fastlyAPIClient->getCurrentlyActiveVersion($serviceId);
+        $context = new FastlyContext(
+            $this->fastlyAPIClient->listSnippets($serviceId, $currentlyActiveVersion),
+            $serviceId,
+            $currentlyActiveVersion
+        );
+
+        $types = scandir($fastlyConfigPath, \SCANDIR_SORT_NONE);
+        \assert($types !== false);
+
+        $changes = [];
+
+        foreach ($types as $type) {
+            if ($type === '.' || $type === '..') {
+                continue;
+            }
+
+            $config = scandir(Path::join($fastlyConfigPath, $type), \SCANDIR_SORT_NONE);
+            \assert($config !== false);
+
+            foreach ($config as $file) {
+                if ($file === '.' || $file === '..') {
+                    continue;
+                }
+
+                if ($this->updateFastlyService($context, $type, Path::join($fastlyConfigPath, $type, $file))) {
+                    $changes[] = \sprintf('%s_%s', $type, $file);
+                }
+            }
+        }
+
+        if ($context->createdVersion !== null) {
+            $this->fastlyAPIClient->activateServiceVersion($serviceId, $context->createdVersion);
+
+            $io->success('Fastly service updated successfully with following snippets: ' . implode(', ', $changes));
+        } else {
+            $io->info('No changes detected in Fastly service configuration.');
+        }
+    }
+
+    private function updateFastlyService(FastlyContext $context, string $type, string $configPath): bool
+    {
+        $configContent = (string) file_get_contents($configPath);
+
+        if (preg_match_all(self::FILE_NAME_REGEX, basename($configPath), $matches, \PREG_SET_ORDER) !== 1) {
+            return false;
+        }
+
+        $name = $matches[0]['name'];
+        $priority = (int) ($matches[0]['priority'] ?? 0);
+
+        if ($name === 'default') {
+            $snippetName = 'shopware_' . $type;
+        } else {
+            $snippetName = 'shopware_' . $type . '.' . $priority;
+        }
+
+        if ($context->hasSnippet($snippetName)) {
+            if ($context->hasSnippetChanged($snippetName, $configContent)) {
+                $newVersionId = $this->getNewVersionId($context);
+                $this->fastlyAPIClient->updateSnippet($context->serviceId, $newVersionId, $snippetName, $type, $configContent, $priority);
+
+                return true;
+            }
+        } else {
+            $newVersionId = $this->getNewVersionId($context);
+            $this->fastlyAPIClient->createSnippet($context->serviceId, $newVersionId, $snippetName, $type, $configContent, $priority);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    private function getNewVersionId(FastlyContext $context): int
+    {
+        if ($context->createdVersion === null) {
+            $response = $this->fastlyAPIClient->cloneServiceVersion($context->serviceId, $context->currentlyActiveVersion);
+            $context->createdVersion = $response;
+        }
+
+        return $context->createdVersion;
+    }
+}

--- a/src/Integration/Fastly/FastlyServiceUpdater.php
+++ b/src/Integration/Fastly/FastlyServiceUpdater.php
@@ -100,7 +100,7 @@ class FastlyServiceUpdater
         if ($name === 'default') {
             $snippetName = 'shopware_' . $type;
         } else {
-            $snippetName = 'shopware_' . $type . '.' . $priority;
+            $snippetName = 'shopware_' . $type . '_' . $name;
         }
 
         if ($context->hasSnippet($snippetName)) {

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -8,6 +8,8 @@
         <defaults autowire="true" autoconfigure="true" public="true"/>
 
         <service id="event_dispatcher" class="Symfony\Component\EventDispatcher\EventDispatcher"/>
+        <service id="Symfony\Contracts\EventDispatcher\EventDispatcherInterface" alias="event_dispatcher"/>
+
         <service id="Doctrine\DBAL\Connection">
             <factory class="Shopware\Deployment\DependencyInjection\MySQLFactory" method="createAndRetry"/>
         </service>

--- a/tests/Command/FastlySnippetListCommandTest.php
+++ b/tests/Command/FastlySnippetListCommandTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Tests\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Deployment\Command\FastlySnippetListCommand;
+use Shopware\Deployment\Integration\Fastly\FastlyAPIClient;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zalas\PHPUnit\Globals\Attribute\Env;
+
+#[CoversClass(FastlySnippetListCommand::class)]
+class FastlySnippetListCommandTest extends TestCase
+{
+    public function testRunCommandWithoutEnv(): void
+    {
+        $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('setApiKey');
+
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('getCurrentlyActiveVersion');
+
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('listSnippets');
+
+        $command = new FastlySnippetListCommand($fastlyAPIClient);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        static::assertEquals(Command::FAILURE, $tester->getStatusCode());
+        static::assertStringContainsString('FASTLY_API_TOKEN or FASTLY_SERVICE_ID is not set.', $tester->getDisplay());
+    }
+
+    #[Env('FASTLY_API_TOKEN', 'apiToken')]
+    #[Env('FASTLY_SERVICE_ID', 'serviceId')]
+    public function testRunCommandWithEnv(): void
+    {
+        $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('setApiKey')
+            ->with('apiToken');
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('getCurrentlyActiveVersion')
+            ->willReturn(1);
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('listSnippets')
+            ->with('serviceId', 1)
+            ->willReturn([
+                ['name' => 'name', 'type' => 'type', 'priority' => 'priority', 'updated_at' => 'updated_at'],
+            ]);
+
+        $command = new FastlySnippetListCommand($fastlyAPIClient);
+        $tester = new CommandTester($command);
+
+        $tester->execute([]);
+
+        static::assertEquals(Command::SUCCESS, $tester->getStatusCode());
+        static::assertStringContainsString('name', $tester->getDisplay());
+        static::assertStringContainsString('type', $tester->getDisplay());
+        static::assertStringContainsString('priority', $tester->getDisplay());
+        static::assertStringContainsString('updated_at', $tester->getDisplay());
+    }
+}

--- a/tests/Command/FastlySnippetRemoveCommandTest.php
+++ b/tests/Command/FastlySnippetRemoveCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Tests\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Deployment\Command\FastlySnippetRemoveCommand;
+use Shopware\Deployment\Integration\Fastly\FastlyAPIClient;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Zalas\PHPUnit\Globals\Attribute\Env;
+
+#[CoversClass(FastlySnippetRemoveCommand::class)]
+class FastlySnippetRemoveCommandTest extends TestCase
+{
+    public function testRunCommandWithoutEnv(): void
+    {
+        $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('setApiKey');
+
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('getCurrentlyActiveVersion');
+
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('listSnippets');
+
+        $command = new FastlySnippetRemoveCommand($fastlyAPIClient);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['snippetName' => 'test']);
+
+        static::assertEquals(Command::FAILURE, $tester->getStatusCode());
+        static::assertStringContainsString('FASTLY_API_TOKEN or FASTLY_SERVICE_ID is not set.', $tester->getDisplay());
+    }
+
+    #[Env('FASTLY_API_TOKEN', 'apiToken')]
+    #[Env('FASTLY_SERVICE_ID', 'serviceId')]
+    public function testRunCommandWithEnv(): void
+    {
+        $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('setApiKey')
+            ->with('apiToken');
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('getCurrentlyActiveVersion')
+            ->willReturn(1);
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('cloneServiceVersion')
+            ->with('serviceId', 1)
+            ->willReturn(2);
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('deleteSnippet')
+            ->with('serviceId', 2, 'test');
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('activateServiceVersion')
+            ->with('serviceId', 2);
+
+        $command = new FastlySnippetRemoveCommand($fastlyAPIClient);
+        $tester = new CommandTester($command);
+
+        $tester->execute(['snippetName' => 'test']);
+
+        static::assertEquals(Command::SUCCESS, $tester->getStatusCode());
+    }
+}

--- a/tests/Command/RunCommandTest.php
+++ b/tests/Command/RunCommandTest.php
@@ -12,6 +12,7 @@ use Shopware\Deployment\Services\InstallationManager;
 use Shopware\Deployment\Services\ShopwareState;
 use Shopware\Deployment\Services\UpgradeManager;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 #[CoversClass(RunCommand::class)]
 class RunCommandTest extends TestCase
@@ -46,6 +47,7 @@ class RunCommandTest extends TestCase
             $installationManager,
             $this->createMock(UpgradeManager::class),
             $hookExecutor,
+            new EventDispatcher()
         );
 
         $tester = new CommandTester($command);
@@ -90,6 +92,7 @@ class RunCommandTest extends TestCase
             $installationManager,
             $upgradeManager,
             $hookExecutor,
+            new EventDispatcher()
         );
 
         $tester = new CommandTester($command);

--- a/tests/Integration/Fastly/FastlyAPIClientTest.php
+++ b/tests/Integration/Fastly/FastlyAPIClientTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Tests\Integration\Fastly;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Deployment\Integration\Fastly\FastlyAPIClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+#[CoversClass(FastlyAPIClient::class)]
+class FastlyAPIClientTest extends TestCase
+{
+    public function testListSnippets(): void
+    {
+        $expectedSnippets = [
+            ['name' => 'snippet1', 'type' => 'recv', 'content' => 'content1', 'priority' => 10, 'updated_at' => '2023-01-01'],
+            ['name' => 'snippet2', 'type' => 'recv', 'content' => 'content2', 'priority' => 20, 'updated_at' => '2023-01-02'],
+        ];
+
+        $client = new FastlyAPIClient(new MockHttpClient([
+            new MockResponse(json_encode($expectedSnippets, \JSON_THROW_ON_ERROR)),
+        ]));
+
+        $client->setApiKey('test_api_key');
+
+        $snippets = $client->listSnippets('service123', 1);
+
+        static::assertEquals($expectedSnippets, $snippets);
+    }
+
+    public function testCreateSnippet(): void
+    {
+        $httpClientMock = $this->createMock(HttpClientInterface::class);
+        $httpClientMock
+            ->expects($this->once())
+            ->method('request')
+            ->with('POST', '/service/service123/version/1/snippet', [
+                'json' => [
+                    'name' => 'new_snippet',
+                    'type' => 'recv',
+                    'content' => 'content',
+                    'dynamic' => 0,
+                    'priority' => 10,
+                ],
+            ]);
+
+        $httpClientMock->method('withOptions')->willReturn($httpClientMock);
+
+        $client = new FastlyAPIClient($httpClientMock);
+
+        $client->setApiKey('test_api_key');
+
+        $client->createSnippet('service123', 1, 'new_snippet', 'recv', 'content', 10);
+    }
+
+    public function testUpdateSnippet(): void
+    {
+        $httpClientMock = $this->createMock(HttpClientInterface::class);
+        $httpClientMock
+            ->expects($this->once())
+            ->method('request')
+            ->with('PUT', '/service/service123/version/1/snippet/snippet1', [
+                'json' => [
+                    'type' => 'recv',
+                    'content' => 'new_content',
+                    'priority' => 20,
+                ],
+            ]);
+
+        $httpClientMock->method('withOptions')->willReturn($httpClientMock);
+
+        $client = new FastlyAPIClient($httpClientMock);
+
+        $client->setApiKey('test_api_key');
+
+        $client->updateSnippet('service123', 1, 'snippet1', 'recv', 'new_content', 20);
+    }
+
+    public function testDeleteSnippet(): void
+    {
+        $httpClientMock = $this->createMock(HttpClientInterface::class);
+        $httpClientMock
+            ->expects($this->once())
+            ->method('request')
+            ->with('DELETE', '/service/service123/version/1/snippet/snippet1');
+
+        $httpClientMock->method('withOptions')->willReturn($httpClientMock);
+
+        $client = new FastlyAPIClient($httpClientMock);
+
+        $client->setApiKey('test_api_key');
+
+        $client->deleteSnippet('service123', 1, 'snippet1');
+    }
+
+    public function testCloneLive(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn(['number' => 2]);
+
+        $httpClientMock = $this->createMock(HttpClientInterface::class);
+        $httpClientMock
+            ->expects($this->once())
+            ->method('request')
+            ->with('PUT', '/service/service123/version/1/clone')
+            ->willReturn($response);
+
+        $httpClientMock->method('withOptions')->willReturn($httpClientMock);
+
+        $client = new FastlyAPIClient($httpClientMock);
+
+        $client->setApiKey('test_api');
+
+        static::assertSame(2, $client->cloneServiceVersion('service123', 1));
+    }
+
+    public function testActivateVersion(): void
+    {
+        $httpClientMock = $this->createMock(HttpClientInterface::class);
+        $httpClientMock
+            ->expects($this->once())
+            ->method('request')
+            ->with('PUT', '/service/service123/version/2/activate');
+
+        $httpClientMock->method('withOptions')->willReturn($httpClientMock);
+
+        $client = new FastlyAPIClient($httpClientMock);
+
+        $client->setApiKey('test_api');
+
+        $client->activateServiceVersion('service123', 2);
+    }
+
+    public function testGetCurrentActiveVersion(): void
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('toArray')->willReturn(['number' => 1]);
+
+        $httpClientMock = $this->createMock(HttpClientInterface::class);
+        $httpClientMock
+            ->expects($this->once())
+            ->method('request')
+            ->with('GET', '/service/service123/version/active')
+            ->willReturn($response);
+
+        $httpClientMock->method('withOptions')->willReturn($httpClientMock);
+
+        $client = new FastlyAPIClient($httpClientMock);
+
+        $client->setApiKey('test_api');
+
+        static::assertSame(1, $client->getCurrentlyActiveVersion('service123'));
+    }
+}

--- a/tests/Integration/Fastly/FastlyContextTest.php
+++ b/tests/Integration/Fastly/FastlyContextTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Tests\Integration\Fastly;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Deployment\Integration\Fastly\FastlyContext;
+
+#[CoversClass(FastlyContext::class)]
+class FastlyContextTest extends TestCase
+{
+    public function testHasSnippet(): void
+    {
+        $context = new FastlyContext([
+            ['name' => 'snippet1', 'type' => 'recv', 'content' => 'content1', 'priority' => 10, 'updated_at' => '2023-01-01'],
+            ['name' => 'snippet2', 'type' => 'recv', 'content' => 'content2', 'priority' => 20, 'updated_at' => '2023-01-02'],
+        ], 'service123', 1);
+
+        static::assertTrue($context->hasSnippet('snippet1'));
+        static::assertFalse($context->hasSnippet('snippet3'));
+    }
+
+    public function testHasSnippetChanged(): void
+    {
+        $context = new FastlyContext([
+            ['name' => 'snippet1', 'type' => 'recv', 'content' => 'content1', 'priority' => 10, 'updated_at' => '2023-01-01'],
+            ['name' => 'snippet2', 'type' => 'recv', 'content' => 'content2', 'priority' => 20, 'updated_at' => '2023-01-02'],
+        ], 'service123', 1);
+
+        static::assertTrue($context->hasSnippetChanged('snippet1', 'content2'));
+        static::assertFalse($context->hasSnippetChanged('snippet1', 'content1'));
+    }
+}

--- a/tests/Integration/Fastly/FastlyServiceUpdaterTest.php
+++ b/tests/Integration/Fastly/FastlyServiceUpdaterTest.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Tests\Integration\Fastly;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Deployment\Event\PostDeploy;
+use Shopware\Deployment\Integration\Fastly\FastlyAPIClient;
+use Shopware\Deployment\Integration\Fastly\FastlyServiceUpdater;
+use Shopware\Deployment\Struct\RunConfiguration;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Filesystem\Filesystem;
+use Zalas\PHPUnit\Globals\Attribute\Env;
+
+#[CoversClass(FastlyServiceUpdater::class)]
+#[CoversClass(PostDeploy::class)]
+class FastlyServiceUpdaterTest extends TestCase
+{
+    public function testDoesNothingWithoutConfigFolder(): void
+    {
+        $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('setApiKey');
+
+        $updater = new FastlyServiceUpdater(__DIR__, $fastlyAPIClient);
+
+        $updater(new PostDeploy(new RunConfiguration(), new NullOutput()));
+    }
+
+    public function testDoesNothingWithoutFastlyApiToken(): void
+    {
+        $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('setApiKey');
+
+        $fs = new Filesystem();
+        $tmpDir = sys_get_temp_dir() . '/' . uniqid('fastly-test-', true);
+
+        $fs->mkdir($tmpDir . '/config/fastly');
+
+        $updater = new FastlyServiceUpdater($tmpDir, $fastlyAPIClient);
+
+        $updater(new PostDeploy(new RunConfiguration(), new NullOutput()));
+
+        $fs->remove($tmpDir);
+    }
+
+    #[Env('FASTLY_API_TOKEN', 'API_TOKEN')]
+    #[Env('FASTLY_SERVICE_ID', 'SERVICE_ID')]
+    public function testCreateSnippet(): void
+    {
+        $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('setApiKey')
+            ->with('API_TOKEN');
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('getCurrentlyActiveVersion')
+            ->willReturn(1);
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('listSnippets')
+            ->with('SERVICE_ID', 1)
+            ->willReturn([]);
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('createSnippet')
+            ->with('SERVICE_ID', 0, 'shopware_deliver', 'deliver', 'TEST');
+
+        $fs = new Filesystem();
+        $tmpDir = $this->createProjectRoot();
+
+        $updater = new FastlyServiceUpdater($tmpDir, $fastlyAPIClient);
+
+        $updater(new PostDeploy(new RunConfiguration(), new NullOutput()));
+
+        $fs->remove($tmpDir);
+    }
+
+    #[Env('FASTLY_API_TOKEN', 'API_TOKEN')]
+    #[Env('FASTLY_SERVICE_ID', 'SERVICE_ID')]
+    public function testCreateSnippetWithPriority(): void
+    {
+        $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('setApiKey')
+            ->with('API_TOKEN');
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('getCurrentlyActiveVersion')
+            ->willReturn(1);
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('listSnippets')
+            ->with('SERVICE_ID', 1)
+            ->willReturn([]);
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('createSnippet')
+            ->with('SERVICE_ID', 0, 'shopware_deliver.5', 'deliver', 'TEST', 5);
+
+        $fs = new Filesystem();
+        $tmpDir = $this->createProjectRoot('test.5.vcl');
+
+        $updater = new FastlyServiceUpdater($tmpDir, $fastlyAPIClient);
+
+        $updater(new PostDeploy(new RunConfiguration(), new NullOutput()));
+
+        $fs->remove($tmpDir);
+    }
+
+    #[Env('FASTLY_API_TOKEN', 'API_TOKEN')]
+    #[Env('FASTLY_SERVICE_ID', 'SERVICE_ID')]
+    public function testUpdateSnippet(): void
+    {
+        $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('setApiKey')
+            ->with('API_TOKEN');
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('getCurrentlyActiveVersion')
+            ->willReturn(1);
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('listSnippets')
+            ->with('SERVICE_ID', 1)
+            ->willReturn([
+                ['name' => 'shopware_deliver', 'priority' => 0, 'content' => 'OLD'],
+            ]);
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('updateSnippet')
+            ->with('SERVICE_ID', 0, 'shopware_deliver', 'deliver', 'TEST');
+
+        $fs = new Filesystem();
+        $tmpDir = $this->createProjectRoot();
+
+        $updater = new FastlyServiceUpdater($tmpDir, $fastlyAPIClient);
+
+        $updater(new PostDeploy(new RunConfiguration(), new NullOutput()));
+
+        $fs->remove($tmpDir);
+    }
+
+    #[Env('FASTLY_API_TOKEN', 'API_TOKEN')]
+    #[Env('FASTLY_SERVICE_ID', 'SERVICE_ID')]
+    public function testContentNotChangedDoesNothing(): void
+    {
+        $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('setApiKey')
+            ->with('API_TOKEN');
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('getCurrentlyActiveVersion')
+            ->willReturn(1);
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('listSnippets')
+            ->with('SERVICE_ID', 1)
+            ->willReturn([
+                ['name' => 'shopware_deliver', 'priority' => 0, 'content' => 'TEST'],
+            ]);
+
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('updateSnippet');
+
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('createSnippet');
+
+        $fs = new Filesystem();
+        $tmpDir = $this->createProjectRoot();
+
+        $updater = new FastlyServiceUpdater($tmpDir, $fastlyAPIClient);
+
+        $updater(new PostDeploy(new RunConfiguration(), new NullOutput()));
+
+        $fs->remove($tmpDir);
+    }
+
+    #[Env('FASTLY_API_TOKEN', 'API_TOKEN')]
+    #[Env('FASTLY_SERVICE_ID', 'SERVICE_ID')]
+    public function testDoesNothingWithUnknownFiles(): void
+    {
+        $fs = new Filesystem();
+        $tmpDir = $this->createProjectRoot('unknown.txt');
+
+        $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('setApiKey')
+            ->with('API_TOKEN');
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('getCurrentlyActiveVersion')
+            ->willReturn(1);
+
+        $fastlyAPIClient
+            ->expects($this->once())
+            ->method('listSnippets')
+            ->with('SERVICE_ID', 1)
+            ->willReturn([
+                ['name' => 'shopware_deliver', 'priority' => 0, 'content' => 'TEST'],
+            ]);
+
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('updateSnippet');
+
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('createSnippet');
+
+        $updater = new FastlyServiceUpdater($tmpDir, $fastlyAPIClient);
+
+        $updater(new PostDeploy(new RunConfiguration(), new NullOutput()));
+
+        $fs->remove($tmpDir);
+    }
+
+    private function createProjectRoot(string $fileName = 'default.vcl'): string
+    {
+        $fs = new Filesystem();
+        $tmpDir = sys_get_temp_dir() . '/' . uniqid('fastly-test-', true);
+
+        $fs->mkdir($tmpDir . '/config/fastly');
+
+        $fs->dumpFile($tmpDir . '/config/fastly/deliver/' . $fileName, 'TEST');
+
+        return $tmpDir;
+    }
+}

--- a/tests/Integration/Fastly/FastlyServiceUpdaterTest.php
+++ b/tests/Integration/Fastly/FastlyServiceUpdaterTest.php
@@ -109,7 +109,7 @@ class FastlyServiceUpdaterTest extends TestCase
         $fastlyAPIClient
             ->expects($this->once())
             ->method('createSnippet')
-            ->with('SERVICE_ID', 0, 'shopware_deliver.5', 'deliver', 'TEST', 5);
+            ->with('SERVICE_ID', 0, 'shopware_deliver_test', 'deliver', 'TEST', 5);
 
         $fs = new Filesystem();
         $tmpDir = $this->createProjectRoot('test.5.vcl');


### PR DESCRIPTION
When a `config/fastly` folder exists and `FASTLY_API_TOKEN` and `FASTLY_SERVICE_ID` env are existing we are syncing them into the Fastly Service. (The `config/fastly` [folder will be created using recipe](https://github.com/shopware/recipes/tree/main/shopware/fastly-meta/6.6/config/fastly)).

It does basically the same as our [bash script with Fastly CLI](https://github.com/shopware/recipes/blob/main/shopware/fastly-meta/6.6/bin/setup-fastly.sh). In PHP it's feels more stable and we have more control over it.

Additional to that we have now commands:

- `shopware-deployment-helper fastly:snippets:list`
- `shopware-deployment-helper fastly:snippets:remove <name>` to remove a specific one


- [ ] Try out that the old tool does not colidate with this new one
