### PR TITLE
Add deployment helper hints to the shell output to understand reason of execution

### DIFF
--- a/bin/shopware-deployment-helper
+++ b/bin/shopware-deployment-helper
@@ -4,6 +4,8 @@
 declare(strict_types=1);
 
 use Shopware\Deployment\Application;
+use Shopware\Deployment\ApplicationOutput;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 error_reporting(-1);
 ini_set('display_errors', 1);
@@ -28,4 +30,4 @@ foreach ($includables as $file) {
 }
 
 $app = new Application();
-$app->run();
+$app->run(output: new ApplicationOutput(new ConsoleOutput()));

--- a/src/ApplicationOutput.php
+++ b/src/ApplicationOutput.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment;
+
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final readonly class ApplicationOutput implements OutputInterface
+{
+    public function __construct(private OutputInterface $decorated)
+    {
+    }
+
+    private function wrapMessage(string $message): string
+    {
+        return preg_replace('#(^|\n)(.)#m', '$1[deployment-helper] $2', $message) ?? $message;
+    }
+
+    /**
+     * @param iterable<array-key, string> $messages
+     *
+     * @return iterable<int, string>
+     */
+    private function wrapMessages(iterable $messages): iterable
+    {
+        foreach ($messages as $message) {
+            yield $this->wrapMessage($message);
+        }
+    }
+
+    public function write(iterable|string $messages, bool $newline = false, int $options = 0): void
+    {
+        if (\is_string($messages)) {
+            $messages = $this->wrapMessage($messages);
+        } else {
+            $messages = $this->wrapMessages($messages);
+        }
+
+        $this->decorated->write($messages, $newline, $options);
+    }
+
+    public function writeln(iterable|string $messages, int $options = 0): void
+    {
+        if (\is_string($messages)) {
+            $messages = $this->wrapMessage($messages);
+        } else {
+            $messages = $this->wrapMessages($messages);
+        }
+
+        $this->decorated->writeln($messages, $options);
+    }
+
+    public function setVerbosity(int $level): void
+    {
+        $this->decorated->setVerbosity($level);
+    }
+
+    public function getVerbosity(): int
+    {
+        return $this->decorated->getVerbosity();
+    }
+
+    public function isQuiet(): bool
+    {
+        return $this->decorated->isQuiet();
+    }
+
+    public function isVerbose(): bool
+    {
+        return $this->decorated->isVerbose();
+    }
+
+    public function isVeryVerbose(): bool
+    {
+        return $this->decorated->isVeryVerbose();
+    }
+
+    public function isDebug(): bool
+    {
+        return $this->decorated->isDebug();
+    }
+
+    public function setDecorated(bool $decorated): void
+    {
+        $this->decorated->setDecorated($decorated);
+    }
+
+    public function isDecorated(): bool
+    {
+        return $this->decorated->isDecorated();
+    }
+
+    public function setFormatter(OutputFormatterInterface $formatter): void
+    {
+        $this->decorated->setFormatter($formatter);
+    }
+
+    public function getFormatter(): OutputFormatterInterface
+    {
+        return $this->decorated->getFormatter();
+    }
+}

--- a/src/Helper/ProcessHelper.php
+++ b/src/Helper/ProcessHelper.php
@@ -146,6 +146,8 @@ class ProcessHelper
 
         fwrite(\STDOUT, \PHP_EOL);
         fwrite(\STDOUT, "=================================================\n");
+        fwrite(\STDOUT, "============== [deployment-helper] ==============\n");
+        fwrite(\STDOUT, "=================================================\n");
         fwrite(\STDOUT, \sprintf("Start: %s\n", $cmdString));
         fwrite(\STDOUT, "=================================================\n");
         fwrite(\STDOUT, \PHP_EOL);
@@ -158,6 +160,8 @@ class ProcessHelper
      */
     private function printPostStart(array $cmd, float $startTime): void
     {
+        fwrite(\STDOUT, "=================================================\n");
+        fwrite(\STDOUT, "============== [deployment-helper] ==============\n");
         fwrite(\STDOUT, "=================================================\n");
         fwrite(\STDOUT, \sprintf("End: %s\n", implode(' ', $cmd)));
         fwrite(\STDOUT, \sprintf(

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -14,7 +14,7 @@
             <factory class="Shopware\Deployment\DependencyInjection\MySQLFactory" method="createAndRetry"/>
         </service>
 
-        <prototype namespace="Shopware\Deployment\" resource="../../" exclude="../../Application.php"/>
+        <prototype namespace="Shopware\Deployment\" resource="../../" exclude="../../Application{,Output}.php"/>
 
         <service id="Shopware\Deployment\Config\ProjectConfiguration">
             <factory class="Shopware\Deployment\Config\ConfigFactory" method="create"/>


### PR DESCRIPTION
I worked more with the deployment helper in depth. This should solve #41 by adding the discussed information about the execution origin. This can now look something like this:

Before executing command:
![grafik](https://github.com/user-attachments/assets/823b0ee7-4a15-444a-b002-252eb0a18f67)

On error:
![grafik](https://github.com/user-attachments/assets/2d3616a9-b4d8-49d8-a5d8-0c119f63c443)
