### PR TITLE
feat: add flag for disableing fastly snippet processing

### DIFF
--- a/src/Integration/Fastly/FastlyServiceUpdater.php
+++ b/src/Integration/Fastly/FastlyServiceUpdater.php
@@ -38,6 +38,12 @@ class FastlyServiceUpdater
 
         $io = new SymfonyStyle(new ArgvInput(), $event->output);
 
+        if (EnvironmentHelper::getVariable('FASTLY_DISABLE_SNIPPET_UPDATE') === '1') {
+            $io->info('FASTLY_DISABLE_SNIPPET_UPDATE is set. Skipping Fastly service update.');
+
+            return;
+        }
+
         if ($apiToken === '' || $serviceId === '') {
             $io->info('FASTLY_API_TOKEN or FASTLY_SERVICE_ID is not set. Skipping Fastly service update.');
 

--- a/tests/Integration/Fastly/FastlyServiceUpdaterTest.php
+++ b/tests/Integration/Fastly/FastlyServiceUpdaterTest.php
@@ -51,6 +51,28 @@ class FastlyServiceUpdaterTest extends TestCase
 
     #[Env('FASTLY_API_TOKEN', 'API_TOKEN')]
     #[Env('FASTLY_SERVICE_ID', 'SERVICE_ID')]
+    #[Env('FASTLY_DISABLE_SNIPPET_UPDATE', '1')]
+    public function testDoesNothingWhenDisabledViaEnv(): void
+    {
+        $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);
+        $fastlyAPIClient
+            ->expects($this->never())
+            ->method('setApiKey');
+
+        $fs = new Filesystem();
+        $tmpDir = sys_get_temp_dir() . '/' . uniqid('fastly-test-', true);
+
+        $fs->mkdir($tmpDir . '/config/fastly');
+
+        $updater = new FastlyServiceUpdater($tmpDir, $fastlyAPIClient);
+
+        $updater(new PostDeploy(new RunConfiguration(), new NullOutput()));
+
+        $fs->remove($tmpDir);
+    }
+
+    #[Env('FASTLY_API_TOKEN', 'API_TOKEN')]
+    #[Env('FASTLY_SERVICE_ID', 'SERVICE_ID')]
     public function testCreateSnippet(): void
     {
         $fastlyAPIClient = $this->createMock(FastlyAPIClient::class);


### PR DESCRIPTION
# Improvement

  Adding a environment flag to disable fastly snippet sync, even if service-id/token and config/fastly is present.

# Reason

  If you don't maintain the fastly snippets in the code, aka supported hosting, then you can't control the snippets. And since they are created per default in the config/fastly this get's activated even if you don't want to use it.

# Information

  We could also add a flag in the operator to disable it, so we can handle it there, but for me that makes more sense to have it in the code itself, so you can disable it even if you don't use the operator.

# Definition of Done

- Decide if we want to add this here
