### PR TITLE
Deployment Helper skill

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -1,0 +1,250 @@
+# Shopware CLI + Deployment Helper Integration Guide
+
+Draft guide for integrating Deployment Helper skill with `shopware-cli ai` command system.
+
+## Overview
+
+Deployment Helper is published as a **Skill** discoverable via `shopware-cli ai info/add/remove`. The skill contains guidance (SKILL.md) published to a repository, and the CLI manages discovery, installation, versioning, and lifecycle.
+
+Key constraints:
+- No automatic updates (user controls when/if to upgrade)
+- Compatibility checks must be owner-maintained (not CLI-maintained)
+- All changes recorded by CLI (tag, revision) for reproducibility
+
+## Architecture
+
+```
+shopware-cli (command interface)
+  ├─ Manifest (YAML, in shopware-cli repo)
+  ├─ Compatibility check script (runs on project before install)
+  └─ Skill content (SKILL.md + metadata, published separately)
+
+deployment-helper skill repo (this project)
+  ├─ SKILL.md (guidance documentation)
+  ├─ skill-manifest.json (metadata: name, description, URL, version)
+  ├─ scripts/compatibility-check.sh (project validation)
+  └─ GitHub Releases (tagged versions)
+```
+
+## Checklist: Essential Elements
+
+### Phase 1: Skill Content & Metadata
+
+- [ ] **SKILL.md updated** (✓ done; see caveman edits)
+  - Covers fresh install, migration, PaaS scenarios
+  - Troubleshooting decision tree
+  - Sources of truth prioritization
+
+- [ ] **Public description (≤75 chars)** needed
+  - Current: "Expert guidance for Deployment Helper operations"
+  - Too long? Shorten to: "Deployment Helper operations and workflows"
+
+- [ ] **Documentation URL** — where users read full SKILL.md
+  - GitHub? `https://github.com/shopware/deployment-helper/blob/main/skills/deployment-helper/skill.md`
+  - Shopware docs? `https://docs.shopware.com/...`
+  - Decision needed
+
+- [ ] **Compatibility requirements** — explicitly declared
+  - PHP 8.2+
+  - Shopware 6.5+
+  - Deployment Helper (any version? or specific range?)
+  - Store access (required for extension management)
+
+### Phase 2: Compatibility Check Script
+
+- [ ] **Create `scripts/compatibility-check.sh`**
+  - Input: project root directory
+  - Output: JSON or exit code indicating pass/fail
+  - Check what?
+    - [ ] PHP version (8.2+)
+    - [ ] Shopware 6.5+ installed or detectable
+    - [ ] Composer available
+    - [ ] DATABASE_URL readable
+    - [ ] .shopware-project.yml exists or can be created
+    - [ ] Deployment Helper already installed? (informational)
+  - Return structure: `{"compatible": true, "warnings": [...], "errors": [...]}`
+
+- [ ] **Test locally** before publishing
+  - Run against sample projects (fresh, existing, PaaS)
+  - Verify error messages are helpful
+
+### Phase 3: Manifest Entry (for shopware-cli repo)
+
+- [ ] **Manifest structure** (YAML, to be added to shopware-cli)
+  ```yaml
+  skills:
+    - id: deployment-helper
+      type: skill
+      name: Shopware Deployment Helper
+      description: Deployment Helper operations and workflows
+      documentation_url: https://...
+      source:
+        type: github
+        owner: shopware
+        repo: deployment-helper
+        path: skills/deployment-helper
+      compatibility:
+        php_min: "8.2"
+        shopware_min: "6.5"
+        check_script: scripts/compatibility-check.sh
+      maintainer:
+        github_team: shopware/deployment-helper-maintainers
+      lifecycle: stable  # or beta, deprecated
+      tags:
+        - deployment
+        - ci-cd
+        - operations
+  ```
+  - [ ] Verify against shopware-cli JSON Schema
+  - [ ] PR to shopware-cli with this entry
+
+### Phase 4: Publishing & Versioning
+
+- [ ] **GitHub Releases workflow** (manual, no CI automation per requirements)
+  - Version: semver (e.g., v1.0.0)
+  - Release notes: what changed in SKILL.md or scripts
+  - Tag must match release version
+  - Include: SKILL.md, skill-manifest.json, scripts/
+
+- [ ] **skill-manifest.json** in skill root
+  ```json
+  {
+    "name": "deployment-helper",
+    "version": "1.0.0",
+    "description": "Deployment Helper operations and workflows",
+    "documentation_url": "https://...",
+    "compatibility": {
+      "php_min": "8.2",
+      "shopware_min": "6.5"
+    },
+    "maintainer": "shopware/deployment-helper-maintainers"
+  }
+  ```
+
+- [ ] **Tag naming**: `v1.0.0` (matches semantic versioning)
+  - CLI resolves tag → fetch commit SHA for reproducibility
+  - Record in user's installation: tag + SHA
+
+### Phase 5: Local Testing
+
+- [ ] **Test `ai add deployment-helper`** workflow (once CLI integration ready)
+  - Fresh project: should install successfully
+  - Existing project: should recognize and migrate-ready
+  - PaaS project (Platform.sh): detect and advise
+  - Incompatible project: should fail with clear error
+
+- [ ] **Test `ai info deployment-helper`**
+  - Shows description, docs URL, version, compatibility
+
+- [ ] **Test `ai remove deployment-helper`**
+  - Removes CLI-managed installation only
+  - Doesn't remove hand-written files
+
+## Maintaining Skill as DH Evolves
+
+### When Deployment Helper Changes
+
+1. **New feature in DH** (e.g., new hook type, extension-management field)
+   - [ ] Update SKILL.md with new operation/configuration
+   - [ ] Add example in "Common Operations" if it's user-facing
+   - [ ] Update compatibility requirements if needed
+   - [ ] Tag as patch or minor release
+
+2. **Breaking change in DH** (e.g., removed config field, new required env var)
+   - [ ] Update SKILL.md troubleshooting section
+   - [ ] Add migration guidance in "Common Operations"
+   - [ ] Bump minimum DH version in compatibility check
+   - [ ] Tag as minor or major release
+
+3. **New hosting platform support** (e.g., AWS Lambda, Fly.io)
+   - [ ] Add section in "Hosting Platform Operations"
+   - [ ] Update compatibility check if platform-specific requirements apply
+   - [ ] Tag as minor release
+
+### When Shopware Version Changes
+
+1. **New Shopware 6.x release**
+   - [ ] Verify DH compatibility via source code
+   - [ ] Update SKILL.md if lifecycle differs (e.g., new schema migration behavior)
+   - [ ] Update compatibility requirement if needed
+
+2. **Shopware 7.0** (future)
+   - [ ] Verify DH supports it
+   - [ ] Update compatibility range (php_min, shopware_min)
+   - [ ] Add guidance for 6.5→7.0 migration if applicable
+   - [ ] Tag as major release
+
+### When PHP Version Changes
+
+1. **PHP 8.3 release**
+   - [ ] No changes unless DH drops 8.2 support
+   - [ ] If 8.2 dropped: update php_min in compatibility check and manifest
+
+## Questions for Integration Developer
+
+### Before Starting
+
+1. **Where will the full SKILL.md live?**
+   - GitHub raw URL? Shopware docs site? Both with sync?
+   - Decision impacts documentation_url in manifest
+
+2. **Who owns the compatibility check?**
+   - Can the DH team maintain it, or CLI team?
+   - What if DH changes and check breaks?
+
+3. **Release cadence?**
+   - How often will SKILL.md be updated (Shopware docs changes, DH updates)?
+   - Who triggers releases (DH team, CLI team)?
+
+4. **Error handling in compatibility check?**
+   - Should it suggest fixes, or just report incompatibility?
+   - JSON output or plaintext?
+
+5. **Multi-environment support?**
+   - Should compatibility check detect Platform.sh, detect staging vs production?
+   - Should it warn about data-leak risks?
+
+### During Integration
+
+1. **Manifest in shopware-cli:**
+   - Does schema match expectations?
+   - Is path to compatibility-check.sh correct?
+   - Is maintainer GitHub team created/accessible?
+
+2. **Local testing:**
+   - Can CLI resolve and install the skill from GitHub?
+   - Does `ai info` display correctly?
+   - Does `ai remove` clean up properly?
+
+3. **Release workflow:**
+   - Should SKILL.md changes auto-publish, or manual?
+   - How to version? (DH version, skill version, or both tracked?)
+
+### Ongoing Maintenance
+
+1. **Monitoring:**
+   - How will DH team learn if skill becomes outdated?
+   - Monthly review? Issue templates? User feedback channel?
+
+2. **Compatibility drift:**
+   - If DH releases major version, how quickly must skill update?
+   - Grace period for deprecation?
+
+3. **PaaS updates:**
+   - If Platform.sh changes integrations, who updates skill guidance?
+   - DH team or platform expert?
+
+## Next Steps
+
+1. **Answer Phase 1 questions** (description, documentation URL)
+2. **Draft compatibility-check.sh** with test cases
+3. **Create skill-manifest.json** (metadata)
+4. **Prepare manifest PR** to shopware-cli (with schema validation)
+5. **Local test** before publishing first release
+6. **Create GitHub Release v1.0.0** with tagged commit
+
+---
+
+**Owner**: Shopware Deployment Helper team  
+**Last updated**: 2026-08-19  
+**Related**: [ADR 0001: AI Command](https://github.com/shopware/shopware-cli/blob/main/docs/adr/0001-ai-command.md)

--- a/SHOPWARE_CLI_MANIFEST_ENTRY.md
+++ b/SHOPWARE_CLI_MANIFEST_ENTRY.md
@@ -1,0 +1,167 @@
+# Shopware CLI Manifest Entry Template
+
+This is a **template** for the manifest entry that will be added to the `shopware-cli` repository.
+
+## Location
+
+File: `https://github.com/shopware/shopware-cli/blob/main/docs/adr/0001-ai-command.md` (or wherever the manifest lives — TBD)
+
+Format: YAML (check shopware-cli for exact location and schema)
+
+## Entry Template
+
+```yaml
+- id: deployment-helper
+  type: skill
+  name: Shopware Deployment Helper
+  description: Deployment Helper operations and workflows
+  documentation_url: https://github.com/shopware/deployment-helper/blob/main/skills/deployment-helper/skill.md
+  source:
+    type: github
+    owner: shopware
+    repo: deployment-helper
+    path: skills/deployment-helper
+    # CLI will fetch from releases, not main branch
+  compatibility_check:
+    script: scripts/compatibility-check.sh
+    owner_maintained: true
+  compatibility:
+    php_min: "8.2"
+    shopware_min: "6.5"
+    deployment_helper: "*"
+  maintainer:
+    github_team: shopware/deployment-helper-maintainers
+    contact: l.apple@shopware.com
+  lifecycle: beta
+  tags:
+    - deployment
+    - ci-cd
+    - operations
+    - server
+```
+
+## Fields Explained
+
+### id
+Stable identifier. Used in commands like `ai add deployment-helper`.
+
+### type
+Always `skill` for this use case.
+
+### name
+Display name (not constrained to 75 chars — that's the description).
+
+### description
+**Max 75 characters.** Shown in `ai list` and `ai info`.
+
+Current: `"Deployment Helper operations and workflows"` (44 chars ✓)
+
+### documentation_url
+URL to full SKILL.md. Users go here for detailed guidance.
+
+Options:
+- GitHub blob URL (updates with repo)
+- Shopware docs site (stable, requires sync)
+- Both (documented in INTEGRATION_GUIDE.md maintainer section)
+
+### source.type
+Always `github` for this project.
+
+### source.owner, source.repo, source.path
+- `owner`: shopware
+- `repo`: deployment-helper
+- `path`: skills/deployment-helper (where SKILL.md and skill-manifest.json live)
+
+CLI will:
+1. Resolve latest GitHub release of `shopware/deployment-helper`
+2. Fetch files from `skills/deployment-helper` directory in that release
+3. Record tag + commit SHA for reproducibility
+
+### compatibility_check.script
+Path within released skill: `scripts/compatibility-check.sh`
+
+CLI runs this **before** installation to validate project.
+
+### compatibility_check.owner_maintained
+`true` — means DH team maintains this script and keeps it compatible.
+
+If `false`, would mean CLI team maintains it (not the case here).
+
+### compatibility fields
+Minimum requirements. Used by CLI for early filtering and by maintainers for decisions.
+
+- `php_min`: "8.2" (minimum PHP version)
+- `shopware_min`: "6.5" (minimum Shopware version)
+- `deployment_helper`: "*" (any DH version is compatible; update if breaking changes occur)
+
+### maintainer.github_team
+GitHub team that owns maintenance: `shopware/deployment-helper-maintainers`
+
+This team:
+- Reviews and approves skill updates
+- Maintains compatibility check script
+- Responds to issues/compatibility questions
+
+**Action required**: Create this team in Shopware GitHub org (if not already exists).
+
+### maintainer.contact
+Fallback contact email (informational).
+
+### lifecycle
+- `beta`: Feature-complete but not widely tested
+- `stable`: Proven production-ready
+- `deprecated`: Scheduled for removal
+
+Start as `beta`, move to `stable` after real-world usage.
+
+### tags
+Help users discover the skill. Examples: `deployment`, `ci-cd`, `operations`, `server`.
+
+## PR Process
+
+1. **Create the entry** (use template above)
+2. **Validate against schema** (shopware-cli CI will check)
+3. **Submit PR** to shopware-cli with this manifest entry
+4. **CI validates**:
+   - JSON Schema compliance
+   - GitHub URLs resolve
+   - Team exists
+5. **Merge** once approved
+
+## Testing Before PR
+
+Before submitting to shopware-cli, ensure:
+
+1. **skill-manifest.json exists** in `skills/deployment-helper/skill-manifest.json`
+2. **SKILL.md exists** at `skills/deployment-helper/skill.md`
+3. **scripts/compatibility-check.sh exists** and is executable
+4. **GitHub release exists** with matching tag (e.g., v1.0.0)
+5. **Release contains all three files** in the correct structure
+6. **documentation_url is valid** and points to live content
+
+## Post-Merge Actions
+
+After manifest PR is merged to shopware-cli:
+
+1. **Wait for CLI release** (includes updated manifest)
+2. **Test locally** with released CLI:
+   ```bash
+   shopware-cli ai info deployment-helper
+   shopware-cli ai add deployment-helper
+   ```
+3. **Verify** installation works on test projects
+4. **Update INTEGRATION_GUIDE.md** with any learnings
+
+## Updating Later
+
+If you need to change the manifest entry (e.g., update `php_min`, change maintainer team):
+
+1. Update entry in shopware-cli repo
+2. Submit PR with justification
+3. Wait for CLI release with updated manifest
+4. Update INTEGRATION_GUIDE.md "Maintaining Skill" section with notes
+
+---
+
+**Related**: [INTEGRATION_GUIDE.md](INTEGRATION_GUIDE.md)  
+**Manifest Validation**: Check shopware-cli repository for JSON Schema definition

--- a/scripts/compatibility-check.sh
+++ b/scripts/compatibility-check.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# Shopware Deployment Helper Skill - Compatibility Check
+# Usage: ./compatibility-check.sh /path/to/project
+# Output: JSON with compatibility status and warnings/errors
+#
+# This script validates that a Shopware project meets minimum requirements
+# for Deployment Helper skill installation and usage.
+
+set -e
+
+# Input: project root directory
+PROJECT_ROOT="${1:-.}"
+if [[ ! -d "$PROJECT_ROOT" ]]; then
+  echo '{"compatible": false, "errors": ["Project directory not found: '"$PROJECT_ROOT"'"]}'
+  exit 1
+fi
+
+# Initialize result
+COMPATIBLE=true
+ERRORS=()
+WARNINGS=()
+INFO=()
+
+# ===== PHP Version =====
+PHP_BIN=$(which php 2>/dev/null || echo "")
+if [[ -z "$PHP_BIN" ]]; then
+  COMPATIBLE=false
+  ERRORS+=("PHP not found in PATH")
+else
+  PHP_VERSION=$("$PHP_BIN" -v | head -n1 | grep -oP '\d+\.\d+' | head -n1)
+  if [[ -z "$PHP_VERSION" ]]; then
+    COMPATIBLE=false
+    ERRORS+=("Could not determine PHP version")
+  else
+    MAJOR_VERSION=$(echo "$PHP_VERSION" | cut -d. -f1)
+    MINOR_VERSION=$(echo "$PHP_VERSION" | cut -d. -f2)
+    if [[ $MAJOR_VERSION -lt 8 ]] || [[ ($MAJOR_VERSION -eq 8 && $MINOR_VERSION -lt 2) ]]; then
+      COMPATIBLE=false
+      ERRORS+=("PHP 8.2+ required, found $PHP_VERSION")
+    else
+      INFO+=("PHP $PHP_VERSION detected")
+    fi
+  fi
+fi
+
+# ===== Shopware Installation Detection =====
+if [[ ! -f "$PROJECT_ROOT/composer.json" ]]; then
+  COMPATIBLE=false
+  ERRORS+=("composer.json not found - not a Shopware project")
+else
+  # Check if shopware/core or shopware/platform is in composer.json
+  if grep -q '"shopware/core"\|"shopware/platform"' "$PROJECT_ROOT/composer.json"; then
+    if grep -q '"shopware/core"\|"shopware/platform"' "$PROJECT_ROOT/composer.json" | grep -q '6\.[5-9]\|7\.'; then
+      INFO+=("Shopware 6.5+ compatible version detected in composer.json")
+    else
+      WARNINGS+=("Shopware version in composer.json may be older than 6.5")
+    fi
+  else
+    WARNINGS+=("Could not verify Shopware version - check composer.json manually")
+  fi
+fi
+
+# ===== Composer Availability =====
+COMPOSER_BIN=$(which composer 2>/dev/null || echo "")
+if [[ -z "$COMPOSER_BIN" ]]; then
+  # Check if composer.phar exists in project
+  if [[ ! -f "$PROJECT_ROOT/composer.phar" ]]; then
+    WARNINGS+=("Composer not found in PATH and composer.phar not found in project")
+  else
+    INFO+=("composer.phar found in project")
+  fi
+else
+  INFO+=("Composer available")
+fi
+
+# ===== Database Configuration =====
+if [[ -f "$PROJECT_ROOT/.env" ]] || [[ -f "$PROJECT_ROOT/.env.local" ]]; then
+  if grep -q "DATABASE_URL" "$PROJECT_ROOT/.env" "$PROJECT_ROOT/.env.local" 2>/dev/null; then
+    INFO+=("DATABASE_URL configured")
+  else
+    WARNINGS+=("DATABASE_URL not found in .env files")
+  fi
+else
+  WARNINGS+=(".env file not found - ensure DATABASE_URL is set at deployment time")
+fi
+
+# ===== .shopware-project.yml Existence =====
+if [[ -f "$PROJECT_ROOT/.shopware-project.yml" ]]; then
+  INFO+=(".shopware-project.yml exists")
+  if grep -q "deployment:" "$PROJECT_ROOT/.shopware-project.yml"; then
+    INFO+=("Deployment configuration section found")
+  else
+    WARNINGS+=(".shopware-project.yml exists but no 'deployment' section - Deployment Helper config needed")
+  fi
+else
+  INFO+=(".shopware-project.yml not found - will be needed for Deployment Helper configuration")
+fi
+
+# ===== Deployment Helper Already Installed =====
+if [[ -f "$PROJECT_ROOT/composer.lock" ]] && grep -q '"shopware/deployment-helper"' "$PROJECT_ROOT/composer.lock"; then
+  INFO+=("Deployment Helper already installed")
+else
+  INFO+=("Deployment Helper not yet installed - must be added via Composer")
+fi
+
+# ===== Output Result =====
+# Build JSON output
+RESULT="{"
+RESULT+='"compatible": '$([[ "$COMPATIBLE" == true ]] && echo "true" || echo "false")',"
+
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  RESULT+='"errors": ['
+  for i in "${!ERRORS[@]}"; do
+    RESULT+="\"${ERRORS[$i]}\""
+    [[ $i -lt $((${#ERRORS[@]} - 1)) ]] && RESULT+=","
+  done
+  RESULT+="],"
+else
+  RESULT+='"errors": [],'
+fi
+
+if [[ ${#WARNINGS[@]} -gt 0 ]]; then
+  RESULT+='"warnings": ['
+  for i in "${!WARNINGS[@]}"; do
+    RESULT+="\"${WARNINGS[$i]}\""
+    [[ $i -lt $((${#WARNINGS[@]} - 1)) ]] && RESULT+=","
+  done
+  RESULT+="],"
+else
+  RESULT+='"warnings": [],'
+fi
+
+if [[ ${#INFO[@]} -gt 0 ]]; then
+  RESULT+='"info": ['
+  for i in "${!INFO[@]}"; do
+    RESULT+="\"${INFO[$i]}\""
+    [[ $i -lt $((${#INFO[@]} - 1)) ]] && RESULT+=","
+  done
+  RESULT+="]"
+else
+  RESULT+='"info": []'
+fi
+
+RESULT+="}"
+
+echo "$RESULT"
+
+# Exit code: 0 = compatible, 1 = incompatible
+[[ "$COMPATIBLE" == true ]] && exit 0 || exit 1

--- a/skills/deployment-helper/SKILL.md
+++ b/skills/deployment-helper/SKILL.md
@@ -1,0 +1,438 @@
+# Shopware Deployment Helper
+
+Use the following context when helping configure, use, or troubleshoot **Shopware Deployment Helper**.
+
+## Role
+
+Act as expert on Deployment Helper operations and workflows. Give practical, implementation-aware guidance based on current Deployment Helper behavior.
+
+When information is uncertain or version-dependent, say so rather than inventing configuration or behavior.
+
+## Build vs Deploy Division
+
+**Shopware CLI (build phase — CI/CD)**:
+- Project setup and validation
+- Dependency compilation
+- Theme building (pre-compiled assets)
+- Artifact preparation
+
+**Deployment Helper (deploy phase — target server)**:
+- Executes deployment-time operations
+- Fresh installs or updates
+- Extension lifecycle management
+- Theme compilation (unless pre-compiled)
+- Hooks and post-deploy integrations
+- Maintenance mode handling
+
+Do not confuse these responsibilities. Deployment Helper is installed through Composer:
+
+```bash
+composer require shopware/deployment-helper
+```
+
+and executed with:
+
+```bash
+vendor/bin/shopware-deployment-helper run
+```
+
+It supports Shopware 6.5+ and requires PHP 8.2+.
+
+## Deployment Lifecycle
+
+`run` determines whether Shopware is installed and follows either **install** or **update** path.
+
+High-level flow:
+
+```text
+pre → install/update → PostDeploy integrations → post
+```
+
+**Install hooks**: `pre-install`, `post-install`
+**Update hooks**: `pre-update`, `post-update`
+
+`post` hook runs only when preceding stages succeed.
+
+Do not assume rerunning a failed deployment starts from same state. Successful steps may persist changes.
+
+## Common Operations
+
+### Fresh Shop Setup
+
+Deployment Helper handles:
+- `system:install`
+- Initial admin and storefront creation
+- Database schema initialization
+- Messenger transport setup
+- Plugin and app installation
+- Hook execution
+- Post-deploy integrations
+
+**Typical flow**:
+1. Database and environment variables ready
+2. First `vendor/bin/shopware-deployment-helper run` triggers install path
+3. Admin credentials set via `INSTALL_ADMIN_*` env vars
+4. Sales channel URL and APP_URL configured
+5. Extensions installed per `extension-management` config
+6. Hooks execute in sequence
+
+### Existing Shop Migration to Deployment Helper
+
+Moving from manual deployments or other tools:
+
+**Pre-migration**:
+- Document current deployment steps and hooks
+- Create `.shopware-project.yml` deployment config matching current procedures
+- Test on staging/non-prod environment first
+- Plan maintenance window if required
+
+**Migration steps**:
+1. Install Deployment Helper via Composer
+2. Define hooks in `.shopware-project.yml` matching existing manual steps
+3. Run `vendor/bin/shopware-deployment-helper run --dry-run` to verify
+4. Enable maintenance mode
+5. Run actual deployment with `vendor/bin/shopware-deployment-helper run`
+6. Disable maintenance mode
+7. Verify shop health post-deployment
+
+**Rollback strategy**:
+- Keep previous deployment method documented and testable until Deployment Helper proven stable
+- Database changes from `system:update:finish` may not be reversible; test carefully
+
+### Shop Updates
+
+Deployment Helper can handle:
+- One-time tasks (idempotent updates)
+- Maintenance mode during update
+- `system:update:finish` when required
+- Cache invalidation
+- Plugin and app updates
+- Theme compilation
+- Post-deploy integrations
+- Staged/production separation
+
+## Configuration
+
+Deployment Helper reads from:
+
+```yaml
+.shopware-project.yml        # Source control
+.shopware-project.local.yml  # Server-specific, not committed
+.shopware-project.local.yaml # Server-specific, not committed
+```
+
+Do not assume Shopware CLI and Deployment Helper interpret fields identically. They have separate implementations.
+
+### Key Configuration Areas
+
+**Hooks** (pre, post, pre-install, post-install, pre-update, post-update):
+```yaml
+deployment:
+  hooks:
+    pre:
+      - %php.bin% bin/console some:command
+```
+
+**Extension management** (install, update, remove, exclude):
+```yaml
+deployment:
+  extension-management:
+    enabled: true
+```
+
+**One-time tasks** (idempotent updates, run once):
+```yaml
+deployment:
+  one-time-tasks:
+    - id: unique-task-id
+      when: before
+      script: %php.bin% bin/console custom:task
+```
+
+**Staging** (data-leak prevention):
+```yaml
+deployment:
+  staging:
+    enabled: true
+```
+
+**Maintenance** (updates only):
+```yaml
+deployment:
+  maintenance:
+    enabled: true
+```
+
+**Cache and theme**:
+```yaml
+deployment:
+  cache:
+    clear: true
+  theme-compile:
+    parallel: true
+    workers: 4
+```
+
+**Store** (license, auth):
+```yaml
+deployment:
+  store:
+    authenticated: true
+```
+
+### Environment Variables
+
+Fresh install:
+- `DATABASE_URL` (required)
+- `INSTALL_LOCALE`, `INSTALL_CURRENCY`
+- `INSTALL_ADMIN_USERNAME`, `INSTALL_ADMIN_PASSWORD`, `INSTALL_ADMIN_EMAIL`
+- `SALES_CHANNEL_URL`, `APP_URL`
+
+Runtime:
+- `SHOPWARE_DEPLOYMENT_TIMEOUT` (seconds, or `null` to disable)
+- `SHOPWARE_DEPLOYMENT_FORCE_REINSTALL` (only when understood)
+
+Never rely on default installation password in production.
+
+## Extension Management Operations
+
+Enable extension lifecycle automation:
+
+```yaml
+deployment:
+  extension-management:
+    enabled: true
+```
+
+**Supported operations**:
+- Install/update apps and plugins from store
+- Remove/deactivate extensions
+- Exclude extensions from updates
+- Force-update specific extensions
+- Per-extension version pinning or overrides
+- Inactive extension handling
+
+**Important**: Plugins and apps have separate implementations. Do not assume behavior is identical between them.
+
+When disabled, plugin/app lifecycle management is skipped, but plugin refresh may still occur.
+
+### Plugin vs App Behavior
+
+During fresh install or update:
+- **Plugins**: File-based, require activate/deactivate commands
+- **Apps**: Store-managed, managed via Shopware admin
+- Update timing and state handling differs
+
+Consult Shopware docs for version-specific plugin/app state machine and lifecycle.
+
+## Hooks: Custom Deployment Operations
+
+Hooks inject custom logic at specific deployment stages:
+
+**Fresh install hooks**:
+- `pre-install`: Before `system:install` (pre-DB setup)
+- `post-install`: After storefront/admin setup, before extensions
+
+**Update hooks**:
+- `pre-update`: Before `system:update:finish` (pre-schema changes)
+- `post-update`: After extension updates, before post-deploy integrations
+
+**Always run**:
+- `pre`: Before all operations (fresh or update)
+- `post`: After all operations (only on success)
+
+Use for custom migrations, cache prewarming, health checks, extension workflows, notifications.
+
+For PHP commands in hooks, prefer `%php.bin%` instead of hardcoding `php`.
+
+## One-Time Tasks: Idempotent Updates
+
+One-time tasks run exactly once (tracked by stable `id`) and are **update-time only**:
+
+```yaml
+deployment:
+  one-time-tasks:
+    - id: migrate-custom-table-schema
+      when: before
+      script: %php.bin% bin/console custom:migrate
+```
+
+**Timing**:
+- `when: before` — before `system:update:finish` (pre-schema changes)
+- `when: after` — default; after schema changes
+
+**Critical**: Make tasks idempotent. On failed deployment, completed tasks persist. On retry, they may run again if not marked complete.
+
+Task is recorded complete only after successful execution. Failed tasks run again next deployment.
+
+Example idempotent task:
+
+```bash
+# Good: checks before applying
+column_exists table column || alter table add column...
+
+# Bad: fails if already applied
+alter table add column...
+```
+
+## Themes and Assets
+
+Deployment Helper normally compiles active themes during deployment.
+
+If themes were already compiled during CI/CD, use:
+
+```bash
+vendor/bin/shopware-deployment-helper run --skip-theme-compile
+```
+
+Asset installation can be skipped with:
+
+```bash
+--skip-assets-install
+```
+
+`--skip-asset-install` is deprecated.
+
+Theme compilation can be parallelized:
+
+```yaml
+deployment:
+  theme-compile:
+    parallel: true
+    workers: 4
+```
+
+## Maintenance and Staging Workflows
+
+**Maintenance mode** and **staging mode** are separate features.
+
+### Maintenance Mode (Updates)
+
+Use for updates to prevent customer-facing issues:
+
+```yaml
+deployment:
+  maintenance:
+    enabled: true
+```
+
+Deployment Helper:
+- Enables maintenance before update
+- Restores previous state after success
+- Does NOT guarantee protection against all partial-failure scenarios
+
+**Typical workflow**:
+1. Customer-facing storefront shows maintenance page
+2. Update executes (migrations, theme compile, extension updates)
+3. Maintenance mode restored to previous state on success
+4. On failure, manually verify storefront state before retry
+
+### Staging Mode (Data-Leak Prevention)
+
+Separate staging environment with restricted access:
+
+```yaml
+deployment:
+  staging:
+    enabled: true
+```
+
+**Purpose**: Prevent accidental data exposure between staging and production.
+
+Deployment Helper invokes Shopware's staging setup during post-deploy phase.
+
+**Typical multi-environment setup**:
+- **Staging**: Separate database, S3 bucket, restricted URL
+- **Production**: Production data and assets
+- Staging deployment includes data-leak prevention measures
+- CI/CD and hooks must not mix environment credentials
+
+## Hosting Platform Operations
+
+Post-deploy integrations vary by platform.
+
+### Platform.sh / Upsun
+
+Deployment Helper detects Platform.sh environment and:
+- Manages database URLs and relationships
+- Configures assets storage
+- Handles environment-specific configuration
+- Integrates with Platform.sh's staging/production separation
+- May handle cache clearing via platform
+
+**Config consideration**: `.shopware-project.yml` environment vars may differ from local development.
+
+### Shopware PaaS Native
+
+Shopware-managed hosting with:
+- Pre-configured database and asset storage
+- Environment separation (staging/production)
+- Post-deploy integration handling
+- Usage-data consent flows
+
+Consult Shopware PaaS documentation for environment-specific configuration.
+
+### Kubernetes
+
+Deployment Helper on Kubernetes:
+- Runs as deployment pod or job
+- DATABASE_URL and other secrets from ConfigMap/Secret
+- Shared storage for assets and theme compilation
+- Timeout may need adjustment for larger shops
+
+Consider pod resource limits and execution timeout when configuring.
+
+### Fastly
+
+Deployment Helper can integrate with Fastly for:
+- Cache invalidation after deployment
+- Surrogate key management
+- VCL updates if configured
+
+### Generic / Self-Hosted
+
+Standard server deployment:
+- All configuration via environment variables or `.shopware-project.local.yml`
+- Manual cache invalidation if CDN in use
+- No platform-specific integrations
+
+### Post-Deploy Operations (All Platforms)
+
+Execution includes:
+- Cache clearing (HTTP, Redis, filesystem)
+- Staging setup and data-leak prevention
+- Fastly integration (if configured)
+- Platform.sh integration (if detected)
+- Shopware usage-data consent handling
+- Plugin refresh and cache warmup
+
+When diagnosing hosting-specific issues, account for platform integrations rather than assuming generic server behavior.
+
+## Troubleshooting Approach
+
+When diagnosing deployment failure, establish context in order:
+
+1. **Build or deploy phase?** Is failure in CI/CD (Shopware CLI) or on server (Deployment Helper)?
+2. **Which operation?** Fresh install, migration, regular update, or PaaS-specific workflow?
+3. **Which lifecycle stage?** `pre` → `install`/`update` → `post-deploy` → `post`?
+4. **Database connectivity?** Can Deployment Helper reach and write DATABASE_URL?
+5. **Environment variables?** Are required vars set (credentials, URLs, locales, timeouts)?
+6. **Configuration?** Is `.shopware-project.yml` or `.shopware-project.local.yml` correct?
+7. **Partial state?** Have earlier deployment steps already persisted changes (schema, extensions, cache)?
+8. **Hooks/tasks?** Are custom hooks or one-time tasks involved? Are they idempotent?
+9. **Extension management?** Are plugin/app lifecycles causing the failure?
+10. **Hosting integration?** Is platform-specific integration involved (Platform.sh, Fastly, Kubernetes)?
+
+Identify the failing **operation** and **stage** before recommending fixes. Do not assume clean state on retry — verify what persisted.
+
+## Sources of truth
+
+When answering questions, use this priority:
+
+1. **Current `shopware/deployment-helper` source code** for actual runtime behavior.
+2. **Current Shopware developer documentation** for supported user-facing configuration and workflows.
+3. This prompt as contextual guidance.
+
+Do not invent commands, configuration keys, environment variables, lifecycle behavior, or integrations.
+
+When current source code or documentation is available, verify version-sensitive details against it before answering.

--- a/skills/deployment-helper/skill-manifest.json
+++ b/skills/deployment-helper/skill-manifest.json
@@ -8,10 +8,6 @@
     "shopware_min": "6.5",
     "deployment_helper": "*"
   },
-  "maintainer": {
-    "github_team": "shopware/deployment-helper-maintainers",
-    "contact_email": "l.apple@shopware.com"
-  },
   "keywords": [
     "deployment",
     "ci-cd",

--- a/skills/deployment-helper/skill-manifest.json
+++ b/skills/deployment-helper/skill-manifest.json
@@ -1,0 +1,26 @@
+{
+  "name": "deployment-helper",
+  "version": "1.0.0-draft",
+  "description": "Deployment Helper operations and workflows",
+  "documentation_url": "https://github.com/shopware/deployment-helper/blob/main/skills/deployment-helper/skill.md",
+  "compatibility": {
+    "php_min": "8.2",
+    "shopware_min": "6.5",
+    "deployment_helper": "*"
+  },
+  "maintainer": {
+    "github_team": "shopware/deployment-helper-maintainers",
+    "contact_email": "l.apple@shopware.com"
+  },
+  "keywords": [
+    "deployment",
+    "ci-cd",
+    "operations",
+    "shopware-cli",
+    "server-deployment"
+  ],
+  "lifecycle": "beta",
+  "changelog": {
+    "1.0.0-draft": "Initial draft for CLI integration, operations-focused guidance"
+  }
+}

--- a/skills/deployment-helper/skill-manifest.json
+++ b/skills/deployment-helper/skill-manifest.json
@@ -8,6 +8,9 @@
     "shopware_min": "6.5",
     "deployment_helper": "*"
   },
+    "maintainer": {
+    "github_team": "shopware/deployment-helper-maintainers",
+  },
   "keywords": [
     "deployment",
     "ci-cd",


### PR DESCRIPTION
## Summary

Publishes the **Deployment Helper skill** (skills.sh conventions) plus its owner-maintained compatibility check, per [issue #1337](https://github.com/shopware/shopware-cli/issues/1337) and [ADR 0001](https://github.com/shopware/shopware-cli/blob/main/docs/adr/0001-ai-command.md). Scoped to what lives in *this* repo — the `shopware-cli ai add/info/remove` command work is separate (see "Out of scope").

Part of #1337 (deployment-helper side).

## What's included

- **`skills/deployment-helper/SKILL.md`** — operations-focused guidance (build-vs-deploy split, lifecycle, hooks, one-time tasks, extension-management, staging/maintenance, themes, hosting platforms, troubleshooting), with skills.sh frontmatter and a "confirm before install/migrate" step. Installable standalone via `npx skills add shopware/deployment-helper`.
- **`skills/deployment-helper/scripts/compatibility-check.sh`** — owner-maintained check the CLI runs before install: PHP ≥ 8.2 and Shopware ≥ 6.5, JSON output, `unknown = incompatible`. Documented in `scripts/README.md`.

Every command, flag, config key and env var in the skill was verified against the Deployment Helper source.

## Out of scope (separate shopware-cli work)

- The `ai add/info/remove/list` command lifecycle, compatibility gating, skills.sh delegation, and recording of tag + resolved revision.
- The **CLI manifest entry** for this skill — directory metadata (description, compatibility, source, maintainer, lifecycle) lives in the shopware-cli manifest, not here: the CLI owns discovery/versioning, the skill ships from the code's own tags, and per #1337 it "carries no metadata format of its own" (one source of truth, no separate skill version — hence no `skill-manifest.json`).
- Deployment Helper execution and deployment authentication — this PR ships guidance + a pre-install check, not a runner; executing `run` and handling credentials (DB, `SHOPWARE_STORE_ACCOUNT_*`, deploy-target auth) stay with the user at deploy time. Per #1337 both are out of scope, preserving the boundary: CLI builds/front-doors, Deployment Helper executes on the server.

## How it was tested

- `compatibility-check.sh` run against fresh / 6.6 / 6.4 / composer.lock fixtures — pass/fail and exit codes verified, including `unknown = incompatible`.
- Skill content cross-checked against `src/` (config schema, run command flags, env vars).

## Related

- Issue: shopware/shopware-cli#1337