### PR TITLE
feat: bootstrap OpenSearch indexes on install

### DIFF
--- a/docs/adr/0002-opensearch-indexing.md
+++ b/docs/adr/0002-opensearch-indexing.md
@@ -27,8 +27,8 @@ Deployment Helper decision.
 
 ## Decision
 
-Deployment Helper will offer OpenSearch indexing as an explicit opt-in through a
-dedicated deployment configuration option. The option is disabled by default.
+Deployment Helper will offer OpenSearch indexing as an explicit opt-in through
+`deployment.opensearch.index-on-install`. The option is disabled by default.
 
 When the option is enabled, Deployment Helper will run Shopware's index commands
 as part of a fresh installation after Shopware has completed its installation and
@@ -65,8 +65,7 @@ commands rather than creating or modifying OpenSearch indexes directly.
 
 ### Negative / trade-offs
 
-- Operators must learn and set an additional Deployment Helper configuration
-  option.
+- Operators must learn and set `deployment.opensearch.index-on-install`.
 - An unavailable or misconfigured OpenSearch service can fail a fresh installation
   when the feature is enabled.
 - The error-versus-fallback policy remains outside Deployment Helper and may differ

--- a/docs/adr/0002-opensearch-indexing.md
+++ b/docs/adr/0002-opensearch-indexing.md
@@ -1,6 +1,6 @@
 # 2. Opt-in OpenSearch bootstrap after fresh installation
 
-- Status: Proposed
+- Status: Accepted
 - Date: 2026-07-28
 
 ## Context

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,4 +13,4 @@ update the old one's status.
 | ADR | Title | Status |
 | --- | --- | --- |
 | [0001](0001-plugin-handling.md) | Plugin handling: load, plan, execute | Accepted |
-| [0002](0002-opensearch-indexing.md) | Opt-in OpenSearch indexing after installation | Proposed |
+| [0002](0002-opensearch-indexing.md) | Opt-in OpenSearch indexing after installation | Accepted |

--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -93,6 +93,12 @@ class ConfigFactory
             }
         }
 
+        if (isset($deployment['opensearch-indexing']) && \is_array($deployment['opensearch-indexing'])) {
+            if (isset($deployment['opensearch-indexing']['enabled']) && \is_bool($deployment['opensearch-indexing']['enabled'])) {
+                $projectConfiguration->openSearchIndexing->enabled = $deployment['opensearch-indexing']['enabled'];
+            }
+        }
+
         if (isset($deployment['store']) && \is_array($deployment['store'])) {
             if (isset($deployment['store']['license-domain']) && \is_string($deployment['store']['license-domain'])) {
                 $projectConfiguration->store->licenseDomain = $deployment['store']['license-domain'];

--- a/src/Config/ConfigFactory.php
+++ b/src/Config/ConfigFactory.php
@@ -93,9 +93,9 @@ class ConfigFactory
             }
         }
 
-        if (isset($deployment['opensearch-indexing']) && \is_array($deployment['opensearch-indexing'])) {
-            if (isset($deployment['opensearch-indexing']['enabled']) && \is_bool($deployment['opensearch-indexing']['enabled'])) {
-                $projectConfiguration->openSearchIndexing->enabled = $deployment['opensearch-indexing']['enabled'];
+        if (isset($deployment['opensearch']) && \is_array($deployment['opensearch'])) {
+            if (isset($deployment['opensearch']['index-on-install']) && \is_bool($deployment['opensearch']['index-on-install'])) {
+                $projectConfiguration->openSearch->indexOnInstall = $deployment['opensearch']['index-on-install'];
             }
         }
 

--- a/src/Config/ProjectConfiguration.php
+++ b/src/Config/ProjectConfiguration.php
@@ -18,6 +18,8 @@ class ProjectConfiguration
 
     public ProjectThemeCompile $themeCompile;
 
+    public ProjectOpenSearchIndexing $openSearchIndexing;
+
     /**
      * @var array<string, \Shopware\Deployment\Struct\OneTimeTask>
      */
@@ -33,5 +35,6 @@ class ProjectConfiguration
         $this->staging = new ProjectStaging();
         $this->store = new ProjectStore();
         $this->themeCompile = new ProjectThemeCompile();
+        $this->openSearchIndexing = new ProjectOpenSearchIndexing();
     }
 }

--- a/src/Config/ProjectConfiguration.php
+++ b/src/Config/ProjectConfiguration.php
@@ -18,7 +18,7 @@ class ProjectConfiguration
 
     public ProjectThemeCompile $themeCompile;
 
-    public ProjectOpenSearchIndexing $openSearchIndexing;
+    public ProjectOpenSearch $openSearch;
 
     /**
      * @var array<string, \Shopware\Deployment\Struct\OneTimeTask>
@@ -35,6 +35,6 @@ class ProjectConfiguration
         $this->staging = new ProjectStaging();
         $this->store = new ProjectStore();
         $this->themeCompile = new ProjectThemeCompile();
-        $this->openSearchIndexing = new ProjectOpenSearchIndexing();
+        $this->openSearch = new ProjectOpenSearch();
     }
 }

--- a/src/Config/ProjectOpenSearch.php
+++ b/src/Config/ProjectOpenSearch.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Shopware\Deployment\Config;
 
-class ProjectOpenSearchIndexing
+class ProjectOpenSearch
 {
-    public bool $enabled = false;
+    public bool $indexOnInstall = false;
 }

--- a/src/Config/ProjectOpenSearchIndexing.php
+++ b/src/Config/ProjectOpenSearchIndexing.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Config;
+
+class ProjectOpenSearchIndexing
+{
+    public bool $enabled = false;
+}

--- a/src/Services/InstallationManager.php
+++ b/src/Services/InstallationManager.php
@@ -110,6 +110,16 @@ class InstallationManager
         $this->appHelper->deactivateApps();
         $this->appHelper->removeApps();
 
+        if ($this->configuration->openSearchIndexing->enabled && EnvironmentHelper::getVariable('SHOPWARE_ES_INDEXING_ENABLED') === '1') {
+            if (EnvironmentHelper::getVariable('OPENSEARCH_URL') !== null) {
+                $this->processHelper->console(['es:index', '--no-queue']);
+            }
+
+            if (EnvironmentHelper::getVariable('ADMIN_OPENSEARCH_URL') !== null) {
+                $this->processHelper->console(['es:admin:index', '--no-queue']);
+            }
+        }
+
         $this->state->setVersion($this->state->getCurrentVersion());
 
         $this->hookExecutor->execute(HookExecutor::HOOK_POST_INSTALL);

--- a/src/Services/InstallationManager.php
+++ b/src/Services/InstallationManager.php
@@ -110,7 +110,7 @@ class InstallationManager
         $this->appHelper->deactivateApps();
         $this->appHelper->removeApps();
 
-        if ($this->configuration->openSearchIndexing->enabled && EnvironmentHelper::getVariable('SHOPWARE_ES_INDEXING_ENABLED') === '1') {
+        if ($this->configuration->openSearch->indexOnInstall && EnvironmentHelper::getVariable('SHOPWARE_ES_INDEXING_ENABLED') === '1') {
             if (EnvironmentHelper::getVariable('OPENSEARCH_URL') !== null) {
                 $this->processHelper->console(['es:index', '--no-queue']);
             }

--- a/tests/Config/ConfigFactoryTest.php
+++ b/tests/Config/ConfigFactoryTest.php
@@ -32,7 +32,7 @@ class ConfigFactoryTest extends TestCase
         static::assertSame([], $config->extensionManagement->overrides);
         static::assertSame([], $config->oneTimeTasks);
         static::assertSame([], $config->hooks->pre);
-        static::assertFalse($config->openSearchIndexing->enabled);
+        static::assertFalse($config->openSearch->indexOnInstall);
     }
 
     public static function files(): \Generator
@@ -105,16 +105,16 @@ class ConfigFactoryTest extends TestCase
         static::assertSame(6, $config->themeCompile->workers);
     }
 
-    public function testExistingConfigWithOpenSearchIndexing(): void
+    public function testExistingConfigWithOpenSearchIndexOnInstall(): void
     {
         $config = ConfigFactory::create(__DIR__ . '/_fixtures/opensearch-indexing', $this->createMockApplication());
-        static::assertTrue($config->openSearchIndexing->enabled);
+        static::assertTrue($config->openSearch->indexOnInstall);
     }
 
-    public function testOpenSearchIndexingIgnoresNonBooleanEnabledValue(): void
+    public function testOpenSearchIgnoresNonBooleanIndexOnInstallValue(): void
     {
         $config = ConfigFactory::create(__DIR__ . '/_fixtures/opensearch-indexing-invalid', $this->createMockApplication());
-        static::assertFalse($config->openSearchIndexing->enabled);
+        static::assertFalse($config->openSearch->indexOnInstall);
     }
 
     public function testThemeCompileWorkersBelowOneAreIgnored(): void

--- a/tests/Config/ConfigFactoryTest.php
+++ b/tests/Config/ConfigFactoryTest.php
@@ -32,6 +32,7 @@ class ConfigFactoryTest extends TestCase
         static::assertSame([], $config->extensionManagement->overrides);
         static::assertSame([], $config->oneTimeTasks);
         static::assertSame([], $config->hooks->pre);
+        static::assertFalse($config->openSearchIndexing->enabled);
     }
 
     public static function files(): \Generator
@@ -102,6 +103,18 @@ class ConfigFactoryTest extends TestCase
         $config = ConfigFactory::create(__DIR__ . '/_fixtures/theme-compile', $this->createMockApplication());
         static::assertTrue($config->themeCompile->parallel);
         static::assertSame(6, $config->themeCompile->workers);
+    }
+
+    public function testExistingConfigWithOpenSearchIndexing(): void
+    {
+        $config = ConfigFactory::create(__DIR__ . '/_fixtures/opensearch-indexing', $this->createMockApplication());
+        static::assertTrue($config->openSearchIndexing->enabled);
+    }
+
+    public function testOpenSearchIndexingIgnoresNonBooleanEnabledValue(): void
+    {
+        $config = ConfigFactory::create(__DIR__ . '/_fixtures/opensearch-indexing-invalid', $this->createMockApplication());
+        static::assertFalse($config->openSearchIndexing->enabled);
     }
 
     public function testThemeCompileWorkersBelowOneAreIgnored(): void

--- a/tests/Config/ProjectConfigurationTest.php
+++ b/tests/Config/ProjectConfigurationTest.php
@@ -9,12 +9,14 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Deployment\Config\ProjectConfiguration;
 use Shopware\Deployment\Config\ProjectHooks;
 use Shopware\Deployment\Config\ProjectMaintenance;
+use Shopware\Deployment\Config\ProjectOpenSearchIndexing;
 use Shopware\Deployment\Config\ProjectStore;
 use Shopware\Deployment\Struct\HookStep;
 
 #[CoversClass(ProjectConfiguration::class)]
 #[CoversClass(ProjectHooks::class)]
 #[CoversClass(ProjectMaintenance::class)]
+#[CoversClass(ProjectOpenSearchIndexing::class)]
 #[CoversClass(ProjectStore::class)]
 #[CoversClass(HookStep::class)]
 class ProjectConfigurationTest extends TestCase
@@ -34,6 +36,7 @@ class ProjectConfigurationTest extends TestCase
         static::assertEmpty($config->extensionManagement->overrides);
 
         static::assertEmpty($config->store->licenseDomain);
+        static::assertFalse($config->openSearchIndexing->enabled);
     }
 
     public function testHooksNormalizeStringIntoSingleUntitledStep(): void

--- a/tests/Config/ProjectConfigurationTest.php
+++ b/tests/Config/ProjectConfigurationTest.php
@@ -9,14 +9,14 @@ use PHPUnit\Framework\TestCase;
 use Shopware\Deployment\Config\ProjectConfiguration;
 use Shopware\Deployment\Config\ProjectHooks;
 use Shopware\Deployment\Config\ProjectMaintenance;
-use Shopware\Deployment\Config\ProjectOpenSearchIndexing;
+use Shopware\Deployment\Config\ProjectOpenSearch;
 use Shopware\Deployment\Config\ProjectStore;
 use Shopware\Deployment\Struct\HookStep;
 
 #[CoversClass(ProjectConfiguration::class)]
 #[CoversClass(ProjectHooks::class)]
 #[CoversClass(ProjectMaintenance::class)]
-#[CoversClass(ProjectOpenSearchIndexing::class)]
+#[CoversClass(ProjectOpenSearch::class)]
 #[CoversClass(ProjectStore::class)]
 #[CoversClass(HookStep::class)]
 class ProjectConfigurationTest extends TestCase
@@ -36,7 +36,7 @@ class ProjectConfigurationTest extends TestCase
         static::assertEmpty($config->extensionManagement->overrides);
 
         static::assertEmpty($config->store->licenseDomain);
-        static::assertFalse($config->openSearchIndexing->enabled);
+        static::assertFalse($config->openSearch->indexOnInstall);
     }
 
     public function testHooksNormalizeStringIntoSingleUntitledStep(): void

--- a/tests/Config/_fixtures/opensearch-indexing-invalid/.shopware-project.yaml
+++ b/tests/Config/_fixtures/opensearch-indexing-invalid/.shopware-project.yaml
@@ -1,3 +1,3 @@
 deployment:
-    opensearch-indexing:
-        enabled: 'true'
+    opensearch:
+        index-on-install: 'true'

--- a/tests/Config/_fixtures/opensearch-indexing-invalid/.shopware-project.yaml
+++ b/tests/Config/_fixtures/opensearch-indexing-invalid/.shopware-project.yaml
@@ -1,0 +1,3 @@
+deployment:
+    opensearch-indexing:
+        enabled: 'true'

--- a/tests/Config/_fixtures/opensearch-indexing/.shopware-project.yaml
+++ b/tests/Config/_fixtures/opensearch-indexing/.shopware-project.yaml
@@ -1,0 +1,3 @@
+deployment:
+    opensearch-indexing:
+        enabled: true

--- a/tests/Config/_fixtures/opensearch-indexing/.shopware-project.yaml
+++ b/tests/Config/_fixtures/opensearch-indexing/.shopware-project.yaml
@@ -1,3 +1,3 @@
 deployment:
-    opensearch-indexing:
-        enabled: true
+    opensearch:
+        index-on-install: true

--- a/tests/Services/InstallationManagerTest.php
+++ b/tests/Services/InstallationManagerTest.php
@@ -6,6 +6,7 @@ namespace Shopware\Deployment\Tests\Services;
 
 use Doctrine\DBAL\Connection;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Shopware\Deployment\Config\ProjectConfiguration;
 use Shopware\Deployment\Helper\ProcessHelper;
@@ -24,6 +25,40 @@ use Zalas\PHPUnit\Globals\Attribute\Env;
 #[Env('APP_URL', 'http://localhost')]
 class InstallationManagerTest extends TestCase
 {
+    /**
+     * @var array<string, array{serverExists: bool, serverValue: mixed, envExists: bool, envValue: mixed}>
+     */
+    private array $environment = [];
+
+    protected function setUp(): void
+    {
+        foreach (['SHOPWARE_ES_INDEXING_ENABLED', 'OPENSEARCH_URL', 'ADMIN_OPENSEARCH_URL'] as $key) {
+            $this->environment[$key] = [
+                'serverExists' => \array_key_exists($key, $_SERVER),
+                'serverValue' => $_SERVER[$key] ?? null,
+                'envExists' => \array_key_exists($key, $_ENV),
+                'envValue' => $_ENV[$key] ?? null,
+            ];
+
+            unset($_SERVER[$key], $_ENV[$key]);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->environment as $key => $environment) {
+            unset($_SERVER[$key], $_ENV[$key]);
+
+            if ($environment['serverExists']) {
+                $_SERVER[$key] = $environment['serverValue'];
+            }
+
+            if ($environment['envExists']) {
+                $_ENV[$key] = $environment['envValue'];
+            }
+        }
+    }
+
     public function testRun(): void
     {
         $hookExecutor = $this->createMock(HookExecutor::class);
@@ -139,6 +174,9 @@ class InstallationManagerTest extends TestCase
 
     public function testRunWithForceReinstall(): void
     {
+        $_SERVER['SHOPWARE_ES_INDEXING_ENABLED'] = '1';
+        $_SERVER['OPENSEARCH_URL'] = 'http://opensearch:9200';
+
         $processHelper = $this->createMock(ProcessHelper::class);
         $consoleCommands = [];
 
@@ -154,6 +192,9 @@ class InstallationManagerTest extends TestCase
         $trackingService = $this->createMock(TrackingService::class);
         $trackingService->expects(static::once())->method('persistId');
 
+        $configuration = new ProjectConfiguration();
+        $configuration->openSearchIndexing->enabled = true;
+
         $manager = new InstallationManager(
             $this->createMock(ShopwareState::class),
             $this->createMock(Connection::class),
@@ -161,16 +202,20 @@ class InstallationManagerTest extends TestCase
             $this->createMock(PluginHelper::class),
             $this->createMock(AppHelper::class),
             $this->createMock(HookExecutor::class),
-            new ProjectConfiguration(),
+            $configuration,
             $accountService,
             $trackingService,
         );
 
         $manager->run(new RunConfiguration(true, true, forceReinstallation: true), $this->createMock(OutputInterface::class));
 
-        static::assertCount(4, $consoleCommands);
-        static::assertSame(['system:install', '--create-database', '--shop-locale=en-GB', '--shop-currency=EUR', '--force', '--no-assign-theme', '--skip-assets-install', '--drop-database'], $consoleCommands[0]);
-        static::assertSame(['user:create', 'admin', '--password=shopware'], $consoleCommands[1]);
+        static::assertSame([
+            ['system:install', '--create-database', '--shop-locale=en-GB', '--shop-currency=EUR', '--force', '--no-assign-theme', '--skip-assets-install', '--drop-database'],
+            ['user:create', 'admin', '--password=shopware'],
+            ['messenger:setup-transports'],
+            ['plugin:refresh'],
+            ['es:index', '--no-queue'],
+        ], $consoleCommands);
     }
 
     #[Env('INSTALL_ADMIN_EMAIL', 'admin@example.com')]
@@ -200,5 +245,109 @@ class InstallationManagerTest extends TestCase
         $manager->run(new RunConfiguration(), $this->createMock(OutputInterface::class));
 
         static::assertSame(['user:create', 'admin', '--password=shopware', '--email=admin@example.com'], $consoleCommands[1]);
+    }
+
+    /**
+     * @param list<list<string>> $expectedIndexCommands
+     */
+    #[DataProvider('openSearchIndexingProvider')]
+    public function testRunOpenSearchIndexing(bool $enabled, ?string $indexingEnabled, ?string $openSearchUrl, ?string $adminOpenSearchUrl, array $expectedIndexCommands): void
+    {
+        if ($indexingEnabled !== null) {
+            $_SERVER['SHOPWARE_ES_INDEXING_ENABLED'] = $indexingEnabled;
+        }
+
+        if ($openSearchUrl !== null) {
+            $_SERVER['OPENSEARCH_URL'] = $openSearchUrl;
+        }
+
+        if ($adminOpenSearchUrl !== null) {
+            $_SERVER['ADMIN_OPENSEARCH_URL'] = $adminOpenSearchUrl;
+        }
+
+        $processHelper = $this->createMock(ProcessHelper::class);
+        $consoleCommands = [];
+        $processHelper
+            ->method('console')
+            ->willReturnCallback(static function (array $command) use (&$consoleCommands): void {
+                $consoleCommands[] = $command;
+            });
+
+        $configuration = new ProjectConfiguration();
+        $configuration->openSearchIndexing->enabled = $enabled;
+
+        $manager = new InstallationManager(
+            $this->createMock(ShopwareState::class),
+            $this->createMock(Connection::class),
+            $processHelper,
+            $this->createMock(PluginHelper::class),
+            $this->createMock(AppHelper::class),
+            $this->createMock(HookExecutor::class),
+            $configuration,
+            $this->createMock(AccountService::class),
+            $this->createMock(TrackingService::class),
+        );
+
+        $manager->run(new RunConfiguration(), $this->createMock(OutputInterface::class));
+
+        static::assertSame($expectedIndexCommands, \array_slice($consoleCommands, 4));
+    }
+
+    public function testRunPropagatesOpenSearchIndexingFailureBeforePostInstallSteps(): void
+    {
+        $_SERVER['SHOPWARE_ES_INDEXING_ENABLED'] = '1';
+        $_SERVER['OPENSEARCH_URL'] = 'http://opensearch:9200';
+
+        $processHelper = $this->createMock(ProcessHelper::class);
+        $processHelper
+            ->method('console')
+            ->willReturnCallback(static function (array $command): void {
+                if ($command === ['es:index', '--no-queue']) {
+                    throw new \RuntimeException('OpenSearch indexing failed');
+                }
+            });
+
+        $state = $this->createMock(ShopwareState::class);
+        $state->expects(static::never())->method('setVersion');
+
+        $hookExecutor = $this->createMock(HookExecutor::class);
+        $hookExecutor
+            ->expects($this->once())
+            ->method('execute')
+            ->with(HookExecutor::HOOK_PRE_INSTALL);
+
+        $configuration = new ProjectConfiguration();
+        $configuration->openSearchIndexing->enabled = true;
+
+        $manager = new InstallationManager(
+            $state,
+            $this->createMock(Connection::class),
+            $processHelper,
+            $this->createMock(PluginHelper::class),
+            $this->createMock(AppHelper::class),
+            $hookExecutor,
+            $configuration,
+            $this->createMock(AccountService::class),
+            $this->createMock(TrackingService::class),
+        );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('OpenSearch indexing failed');
+
+        $manager->run(new RunConfiguration(), $this->createMock(OutputInterface::class));
+    }
+
+    /**
+     * @return iterable<string, array{bool, ?string, ?string, ?string, list<list<string>>}>
+     */
+    public static function openSearchIndexingProvider(): iterable
+    {
+        yield 'storefront only' => [true, '1', 'http://opensearch:9200', null, [['es:index', '--no-queue']]];
+        yield 'admin only' => [true, '1', null, 'http://admin-opensearch:9200', [['es:admin:index', '--no-queue']]];
+        yield 'storefront and admin' => [true, '1', 'http://opensearch:9200', 'http://admin-opensearch:9200', [['es:index', '--no-queue'], ['es:admin:index', '--no-queue']]];
+        yield 'disabled opt-in' => [false, '1', 'http://opensearch:9200', 'http://admin-opensearch:9200', []];
+        yield 'indexing flag is not enabled' => [true, 'true', 'http://opensearch:9200', 'http://admin-opensearch:9200', []];
+        yield 'indexing flag is absent' => [true, null, 'http://opensearch:9200', 'http://admin-opensearch:9200', []];
+        yield 'storefront URL is absent' => [true, '1', null, null, []];
     }
 }

--- a/tests/Services/InstallationManagerTest.php
+++ b/tests/Services/InstallationManagerTest.php
@@ -193,7 +193,7 @@ class InstallationManagerTest extends TestCase
         $trackingService->expects(static::once())->method('persistId');
 
         $configuration = new ProjectConfiguration();
-        $configuration->openSearchIndexing->enabled = true;
+        $configuration->openSearch->indexOnInstall = true;
 
         $manager = new InstallationManager(
             $this->createMock(ShopwareState::class),
@@ -250,8 +250,8 @@ class InstallationManagerTest extends TestCase
     /**
      * @param list<list<string>> $expectedIndexCommands
      */
-    #[DataProvider('openSearchIndexingProvider')]
-    public function testRunOpenSearchIndexing(bool $enabled, ?string $indexingEnabled, ?string $openSearchUrl, ?string $adminOpenSearchUrl, array $expectedIndexCommands): void
+    #[DataProvider('openSearchIndexOnInstallProvider')]
+    public function testRunOpenSearchIndexOnInstall(bool $enabled, ?string $indexingEnabled, ?string $openSearchUrl, ?string $adminOpenSearchUrl, array $expectedIndexCommands): void
     {
         if ($indexingEnabled !== null) {
             $_SERVER['SHOPWARE_ES_INDEXING_ENABLED'] = $indexingEnabled;
@@ -274,7 +274,7 @@ class InstallationManagerTest extends TestCase
             });
 
         $configuration = new ProjectConfiguration();
-        $configuration->openSearchIndexing->enabled = $enabled;
+        $configuration->openSearch->indexOnInstall = $enabled;
 
         $manager = new InstallationManager(
             $this->createMock(ShopwareState::class),
@@ -293,7 +293,7 @@ class InstallationManagerTest extends TestCase
         static::assertSame($expectedIndexCommands, \array_slice($consoleCommands, 4));
     }
 
-    public function testRunPropagatesOpenSearchIndexingFailureBeforePostInstallSteps(): void
+    public function testRunPropagatesOpenSearchIndexOnInstallFailureBeforePostInstallSteps(): void
     {
         $_SERVER['SHOPWARE_ES_INDEXING_ENABLED'] = '1';
         $_SERVER['OPENSEARCH_URL'] = 'http://opensearch:9200';
@@ -317,7 +317,7 @@ class InstallationManagerTest extends TestCase
             ->with(HookExecutor::HOOK_PRE_INSTALL);
 
         $configuration = new ProjectConfiguration();
-        $configuration->openSearchIndexing->enabled = true;
+        $configuration->openSearch->indexOnInstall = true;
 
         $manager = new InstallationManager(
             $state,
@@ -340,7 +340,7 @@ class InstallationManagerTest extends TestCase
     /**
      * @return iterable<string, array{bool, ?string, ?string, ?string, list<list<string>>}>
      */
-    public static function openSearchIndexingProvider(): iterable
+    public static function openSearchIndexOnInstallProvider(): iterable
     {
         yield 'storefront only' => [true, '1', 'http://opensearch:9200', null, [['es:index', '--no-queue']]];
         yield 'admin only' => [true, '1', null, 'http://admin-opensearch:9200', [['es:admin:index', '--no-queue']]];

--- a/tests/Services/UpgradeManagerTest.php
+++ b/tests/Services/UpgradeManagerTest.php
@@ -82,7 +82,7 @@ class UpgradeManagerTest extends TestCase
                 });
 
             $configuration = new ProjectConfiguration();
-            $configuration->openSearchIndexing->enabled = true;
+            $configuration->openSearch->indexOnInstall = true;
 
             $manager = new UpgradeManager(
                 $this->createMock(ShopwareState::class),

--- a/tests/Services/UpgradeManagerTest.php
+++ b/tests/Services/UpgradeManagerTest.php
@@ -54,6 +54,67 @@ class UpgradeManagerTest extends TestCase
         $manager->run(new RunConfiguration(), $this->createMock(OutputInterface::class));
     }
 
+    public function testRunDoesNotIndexOpenSearch(): void
+    {
+        $keys = ['SHOPWARE_ES_INDEXING_ENABLED', 'OPENSEARCH_URL', 'ADMIN_OPENSEARCH_URL'];
+        $environment = [];
+        foreach ($keys as $key) {
+            $environment[$key] = [
+                'serverExists' => \array_key_exists($key, $_SERVER),
+                'serverValue' => $_SERVER[$key] ?? null,
+                'envExists' => \array_key_exists($key, $_ENV),
+                'envValue' => $_ENV[$key] ?? null,
+            ];
+            unset($_SERVER[$key], $_ENV[$key]);
+        }
+
+        try {
+            $_SERVER['SHOPWARE_ES_INDEXING_ENABLED'] = '1';
+            $_SERVER['OPENSEARCH_URL'] = 'http://opensearch:9200';
+            $_SERVER['ADMIN_OPENSEARCH_URL'] = 'http://admin-opensearch:9200';
+
+            $processHelper = $this->createMock(ProcessHelper::class);
+            $consoleCommands = [];
+            $processHelper
+                ->method('console')
+                ->willReturnCallback(static function (array $command) use (&$consoleCommands): void {
+                    $consoleCommands[] = $command;
+                });
+
+            $configuration = new ProjectConfiguration();
+            $configuration->openSearchIndexing->enabled = true;
+
+            $manager = new UpgradeManager(
+                $this->createMock(ShopwareState::class),
+                $processHelper,
+                $this->createMock(PluginHelper::class),
+                $this->createMock(AppHelper::class),
+                $this->createMock(HookExecutor::class),
+                $this->createMock(OneTimeTasks::class),
+                $configuration,
+                $this->createMock(AccountService::class),
+                $this->createMock(TrackingService::class),
+            );
+
+            $manager->run(new RunConfiguration(), $this->createMock(OutputInterface::class));
+
+            static::assertNotContains(['es:index', '--no-queue'], $consoleCommands);
+            static::assertNotContains(['es:admin:index', '--no-queue'], $consoleCommands);
+        } finally {
+            foreach ($environment as $key => $values) {
+                unset($_SERVER[$key], $_ENV[$key]);
+
+                if ($values['serverExists']) {
+                    $_SERVER[$key] = $values['serverValue'];
+                }
+
+                if ($values['envExists']) {
+                    $_ENV[$key] = $values['envValue'];
+                }
+            }
+        }
+    }
+
     public function testRunUpdatesVersion(): void
     {
         $state = $this->createMock(ShopwareState::class);


### PR DESCRIPTION
## Summary
- add a disabled-by-default OpenSearch indexing deployment option
- bootstrap Shopware storefront and administration indexes only during installation
- cover retry, failure propagation, and update exclusion

## Test Plan
- [x] composer test
- [x] composer phpstan
- [x] composer cs-dry