### PR TITLE
fix: pass INSTALL_LOCALE as storefront --isoCode

### DIFF
--- a/src/Services/InstallationManager.php
+++ b/src/Services/InstallationManager.php
@@ -77,7 +77,7 @@ class InstallationManager
         if ($this->state->isStorefrontInstalled()) {
             $this->removeExistingHeadlessSalesChannel();
             if (!$this->state->isSalesChannelExisting($salesChannelUrl)) {
-                $this->processHelper->console(['sales-channel:create:storefront', '--name=Storefront', '--url=' . $salesChannelUrl]);
+                $this->processHelper->console(['sales-channel:create:storefront', '--name=Storefront', '--url=' . $salesChannelUrl, '--isoCode=' . $shopLocale]);
             }
 
             $themeChangeParameters = [];

--- a/src/Services/UpgradeManager.php
+++ b/src/Services/UpgradeManager.php
@@ -75,7 +75,8 @@ class UpgradeManager
         $salesChannelUrl = EnvironmentHelper::getVariable('SALES_CHANNEL_URL');
 
         if ($salesChannelUrl !== null && $this->state->isStorefrontInstalled() && !$this->state->isSalesChannelExisting($salesChannelUrl)) {
-            $this->processHelper->console(['sales-channel:create:storefront', '--name=Storefront', '--url=' . UrlHelper::normalizeSalesChannelUrl($salesChannelUrl)]);
+            $shopLocale = EnvironmentHelper::getVariable('INSTALL_LOCALE', 'en-GB');
+            $this->processHelper->console(['sales-channel:create:storefront', '--name=Storefront', '--url=' . UrlHelper::normalizeSalesChannelUrl($salesChannelUrl), '--isoCode=' . $shopLocale]);
         }
 
         $this->processHelper->console(['plugin:refresh']);

--- a/tests/Services/InstallationManagerTest.php
+++ b/tests/Services/InstallationManagerTest.php
@@ -107,6 +107,43 @@ class InstallationManagerTest extends TestCase
 
         static::assertCount(7, $consoleCommands);
         static::assertSame(['system:install', '--create-database', '--shop-locale=en-GB', '--shop-currency=EUR', '--force', '--no-assign-theme', '--skip-assets-install'], $consoleCommands[0]);
+        static::assertSame(['sales-channel:create:storefront', '--name=Storefront', '--url=http://localhost', '--isoCode=en-GB'], $consoleCommands[3]);
+    }
+
+    #[Env('INSTALL_LOCALE', 'de-DE')]
+    public function testRunCreatesStorefrontWithInstallLocaleIsoCode(): void
+    {
+        $state = $this->createMock(ShopwareState::class);
+        $state->method('isStorefrontInstalled')
+            ->willReturn(true);
+        $state->method('isSalesChannelExisting')
+            ->willReturn(false);
+
+        $processHelper = $this->createMock(ProcessHelper::class);
+        $consoleCommands = [];
+
+        $processHelper
+            ->method('console')
+            ->willReturnCallback(static function (array $command) use (&$consoleCommands): void {
+                $consoleCommands[] = $command;
+            });
+
+        $manager = new InstallationManager(
+            $state,
+            $this->createMock(Connection::class),
+            $processHelper,
+            $this->createMock(PluginHelper::class),
+            $this->createMock(AppHelper::class),
+            $this->createMock(HookExecutor::class),
+            new ProjectConfiguration(),
+            $this->createMock(AccountService::class),
+            $this->createMock(TrackingService::class),
+        );
+
+        $manager->run(new RunConfiguration(), $this->createMock(OutputInterface::class));
+
+        static::assertSame(['system:install', '--create-database', '--shop-locale=de-DE', '--shop-currency=EUR', '--force'], $consoleCommands[0]);
+        static::assertSame(['sales-channel:create:storefront', '--name=Storefront', '--url=http://localhost', '--isoCode=de-DE'], $consoleCommands[3]);
     }
 
     public function testRunWithLicenseDomain(): void

--- a/tests/Services/UpgradeManagerTest.php
+++ b/tests/Services/UpgradeManagerTest.php
@@ -174,7 +174,49 @@ class UpgradeManagerTest extends TestCase
 
         static::assertCount(7, $consoleCommands);
         static::assertArrayHasKey(1, $consoleCommands);
-        static::assertSame(['sales-channel:create:storefront', '--name=Storefront', '--url=http://foo.com'], $consoleCommands[1]);
+        static::assertSame(['sales-channel:create:storefront', '--name=Storefront', '--url=http://foo.com', '--isoCode=en-GB'], $consoleCommands[1]);
+    }
+
+    #[Env('SALES_CHANNEL_URL', 'http://foo.com')]
+    #[Env('INSTALL_LOCALE', 'de-DE')]
+    public function testRunCreatesStorefrontWithInstallLocaleIsoCode(): void
+    {
+        $state = $this->createMock(ShopwareState::class);
+        $state
+            ->expects($this->exactly(2))
+            ->method('isStorefrontInstalled')
+            ->willReturn(true);
+
+        $state
+            ->expects($this->once())
+            ->method('isSalesChannelExisting')
+            ->with('http://foo.com')
+            ->willReturn(false);
+
+        $processHelper = $this->createMock(ProcessHelper::class);
+        $consoleCommands = [];
+
+        $processHelper
+            ->method('console')
+            ->willReturnCallback(static function (array $command) use (&$consoleCommands): void {
+                $consoleCommands[] = $command;
+            });
+
+        $manager = new UpgradeManager(
+            $state,
+            $processHelper,
+            $this->createMock(PluginHelper::class),
+            $this->createMock(AppHelper::class),
+            $this->createMock(HookExecutor::class),
+            $this->createMock(OneTimeTasks::class),
+            new ProjectConfiguration(),
+            $this->createMock(AccountService::class),
+            $this->createMock(TrackingService::class),
+        );
+
+        $manager->run(new RunConfiguration(), $this->createMock(OutputInterface::class));
+
+        static::assertSame(['sales-channel:create:storefront', '--name=Storefront', '--url=http://foo.com', '--isoCode=de-DE'], $consoleCommands[1]);
     }
 
     public function testRunWithMaintenanceMode(): void


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed?

`sales-channel:create:storefront` now receives `--isoCode` from `INSTALL_LOCALE` (default `en-GB`) in both `InstallationManager` and `UpgradeManager`.

## Why?

Shopware's storefront create command assigns the sales-channel language from the system default (so `INSTALL_LOCALE=de-DE` correctly yields Deutsch), but guesses the domain snippet set via `guessSnippetSetId()`. That helper hardcodes `en-GB` when `--isoCode` / `--snippetSetId` are omitted.

The result after a German install was:

- Language: Deutsch
- Snippet set: BASE en-GB

Core `system:install --basic-setup` already forwards `--isoCode` from `--shop-locale` (NEXT-22362). The helper does not use `--basic-setup` and dropped that argument when it creates the storefront itself.

## How was this tested?

- `composer test` — 282 tests, 708 assertions
- `composer phpstan` — no errors
- `composer cs-dry` — no changes
- Local Shopware 6.7.13.1 install via this helper:

  ```
  INSTALL_LOCALE=de-DE INSTALL_CURRENCY=EUR \
    vendor/bin/shopware-deployment-helper run --skip-theme-compile --skip-assets-install
  ```

  The helper invoked:

  ```
  sales-channel:create:storefront --name=Storefront --url=http://127.0.0.1:8000 --isoCode=de-DE
  ```

  Storefront domain after install:

  | URL | Language | Locale | Snippet set | ISO |
  | --- | --- | --- | --- | --- |
  | http://127.0.0.1:8000 | Deutsch | de-DE | BASE de-DE | de-DE |

## Related issue or discussion

Fixes https://github.com/shopware/deployment-helper/issues/102

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9010bb65-995e-4cb1-ba38-c06fb27e7373?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9010bb65-995e-4cb1-ba38-c06fb27e7373&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

