### PR TITLE
feat: add hidden dump-env command for parsed dotenv JSON

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,8 @@ DH unifies post-upload deploy steps: install fresh shops and upgrade live ones, 
 
 Server-side Deployer recipe calls `vendor/bin/shopware-deployment-helper run`. CI may invoke that recipe directly or through another action/wrapper. Config-driven execution: CLI prepares config (`.shopware-project.yml`), DH executes it.
 
+Hidden `dump-env` loads the Symfony dotenv cascade (`.env`, `.env.local`, `.env.$APP_ENV`, compiled `.env.local.php`) and prints the parsed key/value pairs as JSON. Output is unprefixed so other tools can consume it.
+
 ## Under the hood
 
 [Symfony Console app](src/Application.php) with its own dependency injection container. Does not boot Shopware; shells out to `bin/console` via [ProcessHelper](src/Helper/ProcessHelper.php#L15) with timeouts.

--- a/src/Application.php
+++ b/src/Application.php
@@ -102,6 +102,10 @@ class Application extends SymfonyApplication
     {
         $this->projectConfigFile = $input->getParameterOption(['--project-config'], null, true);
 
+        if ($input->getFirstArgument() === 'dump-env' && $output instanceof ApplicationOutput) {
+            $output = $output->getDecorated();
+        }
+
         return parent::doRun($input, $output);
     }
 }

--- a/src/ApplicationOutput.php
+++ b/src/ApplicationOutput.php
@@ -13,6 +13,11 @@ final readonly class ApplicationOutput implements OutputInterface
     {
     }
 
+    public function getDecorated(): OutputInterface
+    {
+        return $this->decorated;
+    }
+
     private function wrapMessage(string $message): string
     {
         return preg_replace('#(^|\n)(.)#m', '$1[deployment-helper] $2', $message) ?? $message;

--- a/src/Command/DumpEnvCommand.php
+++ b/src/Command/DumpEnvCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Command;
+
+use Shopware\Deployment\Services\DotenvLoader;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'dump-env',
+    description: 'Dump parsed environment variables as JSON',
+    hidden: true,
+)]
+class DumpEnvCommand extends Command
+{
+    public function __construct(
+        private readonly DotenvLoader $dotenvLoader,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $json = json_encode(
+            $this->dotenvLoader->parse(),
+            \JSON_THROW_ON_ERROR | \JSON_FORCE_OBJECT | \JSON_UNESCAPED_SLASHES | \JSON_UNESCAPED_UNICODE,
+        );
+
+        $output->writeln($json, OutputInterface::OUTPUT_RAW | OutputInterface::VERBOSITY_QUIET);
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Services/DotenvLoader.php
+++ b/src/Services/DotenvLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shopware\Deployment\Services;
 
+use Shopware\Deployment\Helper\EnvironmentHelper;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\Dotenv\Dotenv;
 
@@ -46,10 +47,10 @@ readonly class DotenvLoader
         try {
             (new Dotenv())->bootEnv($this->projectDir . '/.env', overrideExistingVars: true);
 
-            $names = $_SERVER['SYMFONY_DOTENV_VARS'] ?? $_ENV['SYMFONY_DOTENV_VARS'] ?? '';
+            $names = EnvironmentHelper::getVariable('SYMFONY_DOTENV_VARS', '');
             $values = [];
 
-            foreach (explode(',', (string) $names) as $name) {
+            foreach (explode(',', $names) as $name) {
                 if ($name === '') {
                     continue;
                 }

--- a/src/Services/DotenvLoader.php
+++ b/src/Services/DotenvLoader.php
@@ -17,10 +17,62 @@ readonly class DotenvLoader
 
     public function load(): void
     {
-        if (!file_exists($this->projectDir . '/.env') && !file_exists($this->projectDir . '/.env.dist') && !file_exists($this->projectDir . '/.env.local.php')) {
+        if (!$this->hasEnvFiles()) {
             return;
         }
 
         (new Dotenv())->bootEnv($this->projectDir . '/.env');
+    }
+
+    /**
+     * Parses the Symfony dotenv file cascade and returns the resolved values.
+     *
+     * Existing process environment variables are not included unless they are
+     * also defined in a dotenv file. The current $_ENV / $_SERVER state is
+     * restored afterwards.
+     *
+     * @return array<string, string>
+     */
+    public function parse(): array
+    {
+        if (!$this->hasEnvFiles()) {
+            return [];
+        }
+
+        $server = $_SERVER;
+        $env = $_ENV;
+        unset($_SERVER['SYMFONY_DOTENV_VARS'], $_ENV['SYMFONY_DOTENV_VARS']);
+
+        try {
+            (new Dotenv())->bootEnv($this->projectDir . '/.env', overrideExistingVars: true);
+
+            $names = $_SERVER['SYMFONY_DOTENV_VARS'] ?? $_ENV['SYMFONY_DOTENV_VARS'] ?? '';
+            $values = [];
+
+            foreach (explode(',', (string) $names) as $name) {
+                if ($name === '') {
+                    continue;
+                }
+
+                $value = $_ENV[$name] ?? $_SERVER[$name] ?? null;
+                if (\is_string($value) || \is_int($value) || \is_float($value) || \is_bool($value)) {
+                    $values[$name] = (string) $value;
+                }
+            }
+
+            ksort($values);
+
+            return $values;
+        } finally {
+            $_SERVER = $server;
+            $_ENV = $env;
+        }
+    }
+
+    private function hasEnvFiles(): bool
+    {
+        return file_exists($this->projectDir . '/.env')
+            || file_exists($this->projectDir . '/.env.dist')
+            || file_exists($this->projectDir . '/.env.local.php');
     }
 }

--- a/tests/ApplicationOutputTest.php
+++ b/tests/ApplicationOutputTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Tests;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Deployment\ApplicationOutput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+#[CoversClass(ApplicationOutput::class)]
+class ApplicationOutputTest extends TestCase
+{
+    public function testGetDecoratedReturnsInnerOutput(): void
+    {
+        $inner = new BufferedOutput();
+        $output = new ApplicationOutput($inner);
+
+        static::assertSame($inner, $output->getDecorated());
+    }
+
+    public function testWritePrefixesMessages(): void
+    {
+        $inner = new BufferedOutput();
+        $output = new ApplicationOutput($inner);
+
+        $output->writeln('hello');
+
+        static::assertSame("[deployment-helper] hello\n", $inner->fetch());
+    }
+}

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -7,7 +7,11 @@ namespace Shopware\Deployment\Tests;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Shopware\Deployment\Application;
+use Shopware\Deployment\ApplicationOutput;
+use Shopware\Deployment\Command\DumpEnvCommand;
 use Shopware\Deployment\Command\RunCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 use Zalas\PHPUnit\Globals\Attribute\Env;
 
 #[CoversClass(Application::class)]
@@ -27,5 +31,31 @@ class ApplicationTest extends TestCase
         $app = new Application();
         static::assertTrue($app->getContainer()->has(RunCommand::class));
         static::assertFileExists(\dirname(__DIR__) . '/var/cache/container.xml');
+    }
+
+    #[Env('PROJECT_ROOT', __DIR__ . '/..')]
+    public function testDumpEnvCommandIsRegisteredAndHidden(): void
+    {
+        $app = new Application();
+        $command = $app->get('dump-env');
+
+        static::assertInstanceOf(DumpEnvCommand::class, $command);
+        static::assertTrue($command->isHidden());
+    }
+
+    #[Env('PROJECT_ROOT', __DIR__ . '/..')]
+    public function testDumpEnvOutputIsNotPrefixed(): void
+    {
+        $app = new Application();
+        $app->setAutoExit(false);
+
+        $inner = new BufferedOutput();
+        $exitCode = $app->run(new ArrayInput(['command' => 'dump-env']), new ApplicationOutput($inner));
+        $display = $inner->fetch();
+
+        static::assertSame(0, $exitCode);
+        static::assertJson($display);
+        static::assertStringStartsWith('{', $display);
+        static::assertStringNotContainsString('[deployment-helper]', $display);
     }
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -37,10 +37,10 @@ class ApplicationTest extends TestCase
     public function testDumpEnvCommandIsRegisteredAndHidden(): void
     {
         $app = new Application();
-        $command = $app->get('dump-env');
 
-        static::assertInstanceOf(DumpEnvCommand::class, $command);
-        static::assertTrue($command->isHidden());
+        static::assertTrue($app->getContainer()->has(DumpEnvCommand::class));
+        static::assertTrue($app->has('dump-env'));
+        static::assertTrue($app->get('dump-env')->isHidden());
     }
 
     #[Env('PROJECT_ROOT', __DIR__ . '/..')]

--- a/tests/Command/DumpEnvCommandTest.php
+++ b/tests/Command/DumpEnvCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shopware\Deployment\Tests\Command;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Shopware\Deployment\Command\DumpEnvCommand;
+use Shopware\Deployment\Services\DotenvLoader;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(DumpEnvCommand::class)]
+class DumpEnvCommandTest extends TestCase
+{
+    public function testDumpsParsedValuesAsJson(): void
+    {
+        $loader = $this->createMock(DotenvLoader::class);
+        $loader->expects(static::once())
+            ->method('parse')
+            ->willReturn([
+                'APP_URL' => 'https://example.com',
+                'FOO' => 'bar',
+            ]);
+
+        $tester = new CommandTester(new DumpEnvCommand($loader));
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        static::assertJson($tester->getDisplay());
+        static::assertSame(
+            ['APP_URL' => 'https://example.com', 'FOO' => 'bar'],
+            json_decode($tester->getDisplay(), true, flags: \JSON_THROW_ON_ERROR),
+        );
+    }
+
+    public function testDumpsEmptyObjectWhenNothingIsParsed(): void
+    {
+        $loader = $this->createMock(DotenvLoader::class);
+        $loader->method('parse')->willReturn([]);
+
+        $tester = new CommandTester(new DumpEnvCommand($loader));
+        $exitCode = $tester->execute([]);
+
+        static::assertSame(Command::SUCCESS, $exitCode);
+        static::assertSame("{}\n", $tester->getDisplay());
+    }
+
+    public function testCommandIsHidden(): void
+    {
+        $command = new DumpEnvCommand($this->createMock(DotenvLoader::class));
+
+        static::assertTrue($command->isHidden());
+        static::assertSame('dump-env', $command->getName());
+    }
+
+    public function testDoesNotInterpretFormatterTags(): void
+    {
+        $loader = $this->createMock(DotenvLoader::class);
+        $loader->method('parse')->willReturn(['FOO' => '<info>bar</info>']);
+
+        $tester = new CommandTester(new DumpEnvCommand($loader));
+        $tester->execute([]);
+
+        $tester->assertCommandIsSuccessful();
+        static::assertStringContainsString('<info>bar</info>', $tester->getDisplay());
+    }
+}

--- a/tests/Listener/DotenvListenerTest.php
+++ b/tests/Listener/DotenvListenerTest.php
@@ -34,4 +34,64 @@ class DotenvListenerTest extends TestCase
         $listener->load();
         static::assertArrayHasKey('FOO', $_SERVER);
     }
+
+    public function testParseWithoutFilesReturnsEmptyArray(): void
+    {
+        $loader = new DotenvLoader('/tmp');
+
+        static::assertSame([], $loader->parse());
+    }
+
+    #[BackupGlobals(true)]
+    public function testParseReturnsResolvedDotenvValues(): void
+    {
+        $tmpDir = Path::join(sys_get_temp_dir(), uniqid('test', true));
+        $fs = new Filesystem();
+        $fs->mkdir($tmpDir);
+        $fs->dumpFile($tmpDir . '/.env', "FOO=bar\nBAZ=\${FOO}\nQUX=https://example.com/path");
+
+        $_ENV['FOO'] = 'from-process';
+        $_SERVER['FOO'] = 'from-process';
+
+        $beforeServer = $_SERVER;
+        $beforeEnv = $_ENV;
+
+        $loader = new DotenvLoader($tmpDir);
+        $values = $loader->parse();
+
+        static::assertSame('bar', $values['FOO']);
+        static::assertSame('bar', $values['BAZ']);
+        static::assertSame('https://example.com/path', $values['QUX']);
+        static::assertSame($beforeServer, $_SERVER);
+        static::assertSame($beforeEnv, $_ENV);
+    }
+
+    #[BackupGlobals(true)]
+    public function testParsePrefersLocalOverride(): void
+    {
+        $tmpDir = Path::join(sys_get_temp_dir(), uniqid('test', true));
+        $fs = new Filesystem();
+        $fs->mkdir($tmpDir);
+        $fs->dumpFile($tmpDir . '/.env', "APP_ENV=dev\nFOO=from-env");
+        $fs->dumpFile($tmpDir . '/.env.local', 'FOO=from-local');
+
+        $loader = new DotenvLoader($tmpDir);
+        $values = $loader->parse();
+
+        static::assertSame('from-local', $values['FOO']);
+    }
+
+    #[BackupGlobals(true)]
+    public function testParseReadsEnvDistWhenEnvIsMissing(): void
+    {
+        $tmpDir = Path::join(sys_get_temp_dir(), uniqid('test', true));
+        $fs = new Filesystem();
+        $fs->mkdir($tmpDir);
+        $fs->dumpFile($tmpDir . '/.env.dist', 'FOO=from-dist');
+
+        $loader = new DotenvLoader($tmpDir);
+        $values = $loader->parse();
+
+        static::assertSame('from-dist', $values['FOO']);
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed?

Adds a hidden `dump-env` command that loads the Symfony dotenv cascade and prints the parsed values as JSON.

```bash
vendor/bin/shopware-deployment-helper dump-env
# {"APP_ENV":"dev","FOO":"bar"}
```

- `DotenvLoader::parse()` boots the same file cascade as `load()` (`.env`, `.env.dist`, `.env.local`, `.env.$APP_ENV`, `.env.local.php`), resolves interpolations, and restores `$_ENV` / `$_SERVER` afterwards.
- Only values defined in dotenv files are included (existing process environment variables are not dumped unless they also appear in a file).
- CLI output is unprefixed and written as raw JSON so other tools can consume it. The command is hidden from `list`.

## Why?

Other tools and scripts need the same parsed environment Shopware would see, without reimplementing Symfony dotenv rules (quotes, interpolation, file precedence).

## How was this tested?

- `composer test` — 305 tests, 751 assertions
- `composer phpstan`
- `composer cs-dry`
- Manual smoke test: `dump-env` prints valid JSON (including interpolated values) and does not appear in `list`

## Related issue or discussion

N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf663181-1d92-4e4a-bb77-31ca0f072e57?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf663181-1d92-4e4a-bb77-31ca0f072e57&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

